### PR TITLE
Built 'rake db:seed_test_fixture' to import company data

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,2 +1,3 @@
 class Category < ApplicationRecord
+  has_many :companies
 end

--- a/data/test_fixtures_data/aerospace.txt
+++ b/data/test_fixtures_data/aerospace.txt
@@ -1,0 +1,1208 @@
+A&M AEROSPACE INC.
+2380 S. Delaware St.
+Denver, CO 80223
+303-871-9400
+www.amaerospace.com
+Company headquarters: Denver
+Products/Services: Parts manufacturer for the defense aerospace industry.
+
+
+
+ABSL SPACE PRODUCTS INC./ENERSYS
+1751 S. Fordham St. Suite 100
+Longmont, CO 80503
+303-848-8081
+www.abslspaceproducts.com
+Company headquarters: Redding, PA (EnerSys)
+Products/Services: Supplier of lithium-ion batteries for spacecraft and launch vehicles.
+Person in charge: Kevin Schrantz, director, space
+
+
+ACTION ENGINEERING
+12081 W. Alameda Parkway, Suite 455
+Lakewood, CO 80228
+303-903-7744
+www.action-engineering.com
+Company headquarters: Lakewood
+Products/Services: Consulting services to companies and individuals engaged in the aerospace and defense industries, requiring mechanical and systems engineering services for spacecraft and robots.
+
+
+
+ADAMWORKS
+7367 S. Revere Parkway, Building 2, Unit 2
+Centennial, CO 80112
+303-200-6611
+www.adamworksinc.com
+Company headquarters: Centennial
+Products/Services: AdamWorks designs and builds structures and systems for aerospace & defense industries; from lightweight structures to mechanical systems, manned or unmanned, air and ground.
+
+
+
+ADVANCED AEROTECHNOLOGIES GROUP LLC
+622 Ed Beegles Lane
+Greeley, CO 80631
+970-373-3295
+www.advancedaerotech.com
+Company headquarters: Greeley
+Products/Services: Avionics sales, installation and repair.
+
+
+
+ADVANCED ALLOYS INC.
+600 S. Sunset St., Suite B
+Longmont, CO 80501
+303-702-1997
+www.advancedalloys-inc.com
+Company headquarters: Longmont
+Products/Services: Precision welding, fabrication, prototype and production for the aerospace industry.
+Person in charge: Stan Neighbors, owner
+
+
+ADVANCED MOBILE PROPULSION TEST
+1334 Airport Road
+Durango, CO 81303
+970-247-0840
+www.AMPT.pro
+Company headquarters: Durango
+Products/Services: Provides hot fire test services for hypergolic liquid propellant space propulsion thrusters for reaction and attitude control systems. Offers test engineering services and test stand design.
+Person in charge: Christian Barnes, vice president, business development
+
+
+ADVANCED SOLUTIONS INC.
+7815 Shaffer Parkway
+Littleton, CO 80127
+303-979-2417
+www.go-asi.com
+Company headquarters: Littleton
+Products/Services: Provides system analysis, design and implementation, flight software, and command and telemetry systems.
+Person in charge: Allen Bucher, CEO, owner
+
+
+ADVANCED TECHNOLOGY ASSOCIATES INC.
+6004 S. Kipling St., Suite 208
+Littleton, CO 80127
+303-948-7980
+www.atacolorado.com
+Company headquarters: Littleton
+Products/Services: Provides engineering and management services to the aerospace industry.
+
+
+
+ADVANCED THIN FILMS LLC
+5733 Central Ave.
+Boulder, CO 80301
+303-815-1545
+www.atf-ppc.com
+Company headquarters: Boulder
+Products/Services: Precision optical components and ion beam sputtered coatings for applications in scientific research, defense, aerospace, telecommunications, laser and semiconductor manufacturing.
+Person in charge: Robert Beeson, general manager
+
+
+AERO SPECTRA INC.
+P.O. Box 3021
+Boulder, CO 80305
+303-499-2584
+www.aerospectra.com
+Company headquarters: Boulder
+Products/Services: Electronics systems development, engineering design and analysis, and airborne remote and in situ sensing.
+Person in charge: James Hauser, President
+
+
+AEROFLEX RAD
+4350 Centennial Blvd.
+Colorado Springs, CO 80907
+719-594-8000
+www.aeroflex.com
+Company headquarters: Colorado Springs
+Products/Services: Supplies integrated circuits and circuit card assemblies for the aerospace, commercial communication and industrial markets.
+
+
+
+AEROJET ROCKETDYNE INC.
+P.O. Box 13222
+Sacramento, CA 95813
+916-355-2610
+
+Company headquarters: Rancho Cordova, CA
+Products/Services: Provides propulsion and energetics to space, missile defense, strategic, tactical missile and armaments customers.
+Person in charge: Scott Seymour, CEO GenCorp
+
+
+AEROSPACE TECHNOLOGIES INTERNATIONAL INC.
+2945 Center Green Court South, Suite C
+Boulder, CO 80301-5412
+303-449-1003
+www.atintl.net
+Company headquarters: Boulder
+Products/Services: Providers of aerospace components and services to the domestic and international aviation communities.
+Person in charge: Debbie Halevi, president
+
+
+AIR COMM CORP.
+1575 W. 124th Ave., Suite 210
+Westminster, CO 80234
+303-440-4075
+www.aircommcorp.com
+Company headquarters: Westminster
+Products/Services: Climate-control systems for civil and military aircraft.
+Person in charge: Keith Steiner, CEO
+
+
+AIR MANAGEMENT TECHNOLOGY INC.
+12741 E. Caley Ave., Suite 140
+Centennial, CO 80111
+720-638-6285
+www.amt-aero.com
+Company headquarters: Centennial
+Products/Services: Provides air-conditioning, heating and pressurization solutions for the light business jet and turboprop aircraft industry.
+
+
+
+AITECH DEFENSE SYSTEMS INC.
+3981 Stonegrass Point
+Broomfield, CO 80023
+303-466-7185
+www.rugged.com
+Company headquarters: Chatsworth, CA
+Products/Services: Colorado regional office of Aitech Defense Systems — a provider of rugged commercial and military embedded computing solutions for the aerospace and defense industry.
+
+
+
+ALEUT GLOBAL SOLUTIONS
+5540 Tech Center Drive, Suite 100
+Colorado Springs, CO 80919
+719-264-0620
+www.aleutmgt.com
+Company headquarters: Colorado Springs
+Products/Services: Full-service small business with top-secret clearance that delivers civil engineering, satellite operations and logistics services to federal agencies, including DoD, DHS, NOAA and NASA.
+
+
+
+ALPHA MOLD WEST
+7005 W. 116th Ave.
+Broomfield, CO 80020-2998
+303-465-1701
+www.alphamoldwest.com
+Company headquarters: Broomfield
+Products/Services: Makes plastic injection molds for the aerospace, appliance, automotive, computer, communications, electrical, food packaging and medical industries.
+Person in charge: Dane Whittington, president
+
+
+ALTAIR INDUSTRIES INC.
+217 Racquette Drive, Suite 5
+Fort Collins, CO 80524
+970-217-1623
+www.altairindustriesinc.com
+Company headquarters: Fort Collins
+Products/Services: Offers stand alone automation/processing equipment and tabletop workstations. Clients include medical, aerospace and high-tech manufacturing companies.
+
+
+
+ALTIUS SPACE MACHINES
+3001 Industrial Lane, Suite 5
+Broomfield, CO 80020
+303-827-1574
+www.altius-space.com
+Company headquarters: Broomfield
+Products/Services: A space robotics technology company that is developing SmallSat Deployment Systems, ISS “Shirt Sleeve” Glovebox Robotics and various other technologies.
+Person in charge: Jonathan Goff, CEO, president
+
+
+ALVAREZ LLC
+9635 Maroon Circle , Suite 340
+Englewood, CO 80112
+303-569-6353
+www.alvarezassociates.com
+Company headquarters: Tysons Corner, VA
+Products/Services: Delivers IT solutions to federal and commercial clients.
+
+
+
+AMPEX DATA SYSTEMS CORP.
+4184 E. Bijou St.
+Colorado Springs, CO 80909
+719-596-2000
+www.ampexdata.com
+Company headquarters: Redwood City, CA
+Products/Services: Supplier of high-capacity, high performance digital storage systems capable of functioning in demanding environments on land, at sea or in the air.
+
+
+
+ANALYTICAL GRAPHICS INC.
+7150 Campus Drive, Suite 260
+Colorado Springs, CO 80920
+719-573-2600
+www.agi.com
+Company headquarters: Exton, PA
+Products/Services: Provides geospatial analysis and visualization software for aerospace, defense, and intelligence applications.
+
+
+
+APPLIED DESIGN CORP.
+5311 Western Ave., Suite 131
+Boulder, CO 80301
+303-444-3125
+www.applieddesigncorp.com
+Company headquarters: Boulder
+Products/Services: Engineering, specialty FEA & CFD analysis, contract R&D, product development, technology management solutions and professional technical staffing.
+Person in charge: Michael Messaros, president/CEO
+
+
+ARES CORP.
+7921 Southpark Plaza, Suite 105
+Littleton, CO 80120
+303-225-0540
+www.arescorporation.com
+Company headquarters: Burlingame, CA
+Products/Services: Provides consulting services and solutions in engineering, risk management, reliability assurance, software and project management.
+
+
+
+ARES CORP.
+1330 Inverness Drive, Suite 230
+Colorado Springs, CO 80910
+719-484-8640
+www.arescorporation.com
+Company headquarters: Burlingame, CA
+Products/Services: Provides consulting services and solutions in engineering, risk management, reliability assurance, software and project management.
+
+
+
+ASPEN ELECTRONICS MANUFACTURING INC.
+8975 Marshall Court, Suite 100
+Westminster, CO 80031
+303-412-1216
+aemtronics.com
+Company headquarters: Westminster
+Products/Services: Engineering contract manufacturing company, providing printed circuit board assembly services for computer, commercial, aerospace and medical device industries.
+
+
+
+AT&T GLOBAL BUSINESS — PUBLIC SECTOR SOLUTIONS
+985 Space Center Drive, Suite 310
+Colorado Springs, CO 80915
+719-596-5395
+www.corp.att.com/gov
+Company headquarters: Dallas, TX
+Products/Services: Provides computer integration and engineering research and development for space and defense industries.
+
+
+
+ATMOSPHERIC OBSERVING SYSTEMS INC.
+1930 Central Ave., Suite A
+Boulder, CO 80301
+303-443-3389
+www.aosinc.net
+Company headquarters: Boulder
+Products/Services: Calibration/validation technology for the CO2 satellite.
+
+
+
+AVIATION INFORMATION SERVICES INC.
+6623 E. Phillips Ave.
+Centennial, CO 80112
+303-719-8793
+www.ais-software.com
+Company headquarters: Centennial
+Products/Services: Developer of aviation management software for corporate, government and military flight departments.
+
+
+
+AVIOR CONTROL TECHNOLOGIES INC.
+2000 Pike Road
+Longmont, CO 80501
+720-491-3708
+www.AviorControls.com
+Company headquarters: Longmont
+Products/Services: A full-service custom high-performance motor and motion control house, specifically servicing space, high vacuum and high reliability industries.
+Person in charge: Scott Starin, vice president
+
+
+AVSPEC AVIONICS SPECIALISTS LLC
+5297 Gulfstream Court
+Loveland , CO 80538
+970-203-0505
+www.avspec.aero
+Company headquarters: Loveland
+Products/Services: Avionics sales, installation, service and training.
+
+
+
+BACH RESEARCH CORP.
+4946 N. 63rd St.
+Boulder, CO 80301
+303-444-3602
+www.bachresearch.com
+Company headquarters: Boulder
+Products/Services: Custom precision optics and diffraction gratings for spaceflight, aerospace and university research applications.
+Person in charge: Erich Bach, president
+
+
+BAE SYSTEMS
+8610 Explorer Drive, Suite 115
+Colorado Springs, CO 80920
+719-637-1161
+www.baesystems.com
+Company headquarters: Arlington, VA
+Products/Services: Provides software development, engineering and associated support functions for defense industry.
+Person in charge: Steven Kestner, CEO
+
+
+BALL AEROSPACE & TECHNOLOGIES CORP.
+1600 Commerce St.
+Boulder, CO 80301-2734
+303-939-6100
+www.ballaerospace.com
+Company headquarters: Boulder
+Products/Services: Develops and manufactures spacecraft, advanced instruments and sensors, components, data exploitation systems and RF solutions for strategic, tactical and scientific applications.
+Person in charge: John A. Hayes, CEO, president
+
+
+BALL CORP.
+10 Longs Peak Drive
+Broomfield, CO 80021
+303-469-3131
+www.ball.com
+Company headquarters: Broomfield
+Products/Services: Packaging; aerospace unit.
+Person in charge: John A. Hayes, CEO
+
+
+BARBER-NICHOLS INC.
+6325 W. 55th Ave.
+Arvada, CO 80002
+303-421-8111
+www.barber-nichols.com
+Company headquarters: Arvada
+Products/Services: Produces high-performance turbo machinery for the commercial, defense and aerospace industries.
+Person in charge: Robert Barnaby, CEO
+
+
+BD SYSTEMS INC.
+360 Command View
+Colorado Springs, CO 80915
+719-474-8000
+www.bdsys.com
+Company headquarters: Colorado Springs
+Products/Services: Provides aerospace engineering and information systems services.
+
+
+
+BIOSERVE SPACE TECHNOLOGIES
+429 UCB, ECAE 1B02
+Boulder, CO 80309-0429
+303-735-5308
+www.colorado.edu/engineering/BioServe
+Company headquarters: Boulder
+Products/Services: Develops products using space life sciences research; forms strategic partnerships with industry, academia and government.
+
+
+
+BITSOFT SYSTEMS INC.
+P.O. Box 270324
+Fort Collins, CO 80527
+303-775-1928
+www.bitsoftsystems.com
+Company headquarters: Aurora, IL
+Products/Services: Develops avionics and flight-control systems and software.
+
+
+
+BLUE CANYON TECHNOLOGIES
+2425 55th St, Suite #200, Bldg. A
+Boulder, CO 80301
+720-458-0703
+www.bluecanyontech.com
+Company headquarters: Boulder
+Products/Services: Small spacecraft buses, systems, and components.
+Person in charge: George Stafford, CEO and president
+
+
+BLUE SUN ENTERPRISES INC.
+1942 Broadway, Suite 314
+Boulder, CO 80302
+720-394-8897
+www.bluesunenterprises.com
+Company headquarters: Boulder
+Products/Services: Develops and deploys a variety of flight software and ground software components for space missions.
+
+
+
+BOULDER INNOVATION GROUP INC.
+4824 Sterling Drive
+Boulder, CO 80301
+303-447-0248
+www.boulderinnovators.com
+Company headquarters: Boulder
+Products/Services: Manufacture real-time, free-hand, 3-D digitizer of points in 3-D space for medical and industrial applications; involved in manufacturing of camera systems, scanners, trackers, fiber-optic systems.
+Person in charge: Ivan Faul, president
+
+
+CASCADE TEK
+1530 Vista View Drive
+Longmont, CO 80504
+720-340-7810
+www.cascadetek.com
+Company headquarters: Hillsboro, Oregon
+Products/Services: Accredited product reliability testing lab. Performing tests such as vibration, drop shock, temperature/humidity, altitude, UV exposure, aging, blowing sand/dust, transportation simulation.
+Person in charge: Joe Fratiello, laboratory manager
+
+
+COLORADO PLATING LLC
+9616 Metro Airport Ave., Hangar 44
+Broomfield, CO 80021
+303-469-1749
+www.coloradoplating.com
+Company headquarters: Broomfield
+Products/Services: Provides cadmium plating and embrittlement relief and powder coating and repair services.
+Person in charge: CJ Howard, President
+
+
+COMPOSITE TECHNOLOGY DEVELOPMENT INC.
+2600 Campus Drive, Suite D
+Lafayette, CO 80026-3359
+303-664-0394
+www.ctd-materials.com
+Company headquarters: Lafayette
+Products/Services: Composite products for energy/aerospace/defense including electrical/thermal insulation, resins/adhesives, composite tanks, solar arrays and satellite components. Testing/engineering & design service.
+Person in charge: Naseem A. Munshi, president
+
+
+COMPUTRAK
+515 Kim Drive
+Fort Collins, CO 80525
+970-493-6886
+www.computrak.org
+
+
+
+
+
+CUSTOM MICROWAVE INC.
+24 Boston Court
+Longmont, CO 80501
+303-651-0707 ext. 19
+www.custommicrowave.com
+Company headquarters: Longmont
+Products/Services: Precision design, manufacture, and test of high performance feeds for reflector antennas used on satellites. Precision fabrication of microwave components.
+Person in charge: Clency Lee-Yow, president
+
+
+DC’S MACHINING PRODUCTS INC.
+1121 Delaware St.
+Longmont, CO 80501
+303-772-1160
+
+Company headquarters: Longmont
+Products/Services: Machine shop.
+
+
+
+DIGITALGLOBE INC.
+1601 Dry Creek Drive, Suite 260
+Longmont, CO 80503
+303-684-4000
+www.digitalglobe.com
+Company headquarters: Westminster, CO
+Products/Services: Provides high-resolution satellite imagery.
+Person in charge: Jeffrey R. Tarr, CEO
+
+
+DIGITALGLOBE INC.
+1300 W. 120th Ave.
+Westminster, CO 80234
+303-684-4000
+www.digitalglobe.com
+Company headquarters: Westminster, CO
+Products/Services: Provides high-resolution satellite imagery.
+Person in charge: Jeffrey R. Tarr, CEO
+
+
+DSOFT TECHNOLOGY CO.
+1155 Kelly Johnson Blvd., Suite 304
+Colorado Springs, CO 80920-3958
+719-598-7107
+www.dsoft-tech.com
+Company headquarters: Colorado Springs
+Products/Services: .NET development, Umbraco, systems engineering, mobile systems.
+Person in charge: David Hollenbach, president/CEO
+
+
+DUKE SOURCE DBA THE NEW FIREWALL FORWARD
+5212 Cessna Drive
+Loveland, CO 80538
+970-669-6185
+www.thenewfirewallforward.com
+Company headquarters: Chino, CA
+Products/Services: Aircraft piston engine overhaul, STCs, and upgrades. Airframe inspections and maintenance.
+Person in charge: Frank Szymanski, general manager
+
+
+ENSIGN POWER SYSTEMS INC.
+2175 Citrine Court
+Loveland, CO 80537
+970-203-9255
+www.ensignpower.com
+Company headquarters: Loveland, CO
+Products/Services: Designer and manufacturer of electronic power supplies.
+Person in charge: R. Larry Choate, vicepresident
+
+
+EQUINOX INTERSCIENCE INC.
+352 Evergreen Way
+Nederland, CO 80466
+303-421-6441
+www.eisci.com
+Company headquarters: Pinecliffe
+Products/Services: Designs and builds science instruments, including astronomical telescopes, electro-optical sensors and precision pointing and tracking platforms
+Person in charge: Russell R Mellon, President and Chief Engineer
+
+
+ESTESGROUP
+3780 E 15th St., Suite 101
+Loveland, CO 80538
+888-300-2340
+www.estesgrp.com
+Company headquarters: Estes Park
+Products/Services: IT services, including enterprise resource planning and cloud services.
+Person in charge: Bruce Grant, CEO
+
+
+FREEDOM AVIONICS CO.
+11905 Airport Way
+Broomfield , CO 80021
+303-469-5633
+www.freedomairavionics.com
+
+
+Person in charge: Bret Tredway, President Dane Duran, Vice-President heriS Tredway, Sec/Tres
+
+
+FRONTIER METAL STAMPING, INC.
+3764 Puritan Way
+Frederick, CO 80516
+303-458-5129
+www.frontiermetal.com
+Company headquarters: Frederick
+Products/Services: Metal stamping, fabricating, blanking, bending, forming custom parts.
+Person in charge: Steven O’Donnell, president
+
+
+FRONTLINE AEROSPACE INC.
+14004 Quail Ridge Drive
+Broomfield, CO 80020
+720-887-8171
+www.frontlineaerospace.com
+Company headquarters: Broomfield
+Products/Services: Gas turbine performance upgrades for the Rolls-Royce Model 250 and other gas turbines.
+Person in charge: Ryan Wood, CEO/CTO
+
+
+GOGO BUSINESS AVIATION
+105 Edgeview Court, Suite 300
+Broomfield, CO 80021
+888-328-0200
+business.gogoair.com
+Company headquarters: Itasca, IL
+Products/Services: In-flight communication and in-flight entertainment for business aircraft.
+Person in charge: Michael Small, CEO
+
+
+GOLDEN SPIKE CO.
+
+Boulder, CO
+
+www.goldenspikecompany.com
+
+Products/Services: Developing Orbital and surface expeditions to the moon.
+Person in charge: Alan Stern, CEO/president
+
+
+HONEYBEE ROBOTICS
+1860 Lefthand Circle, Unit C
+Longmont, CO 80501
+303-774-7613
+www.honeybeerobotics.com
+Company headquarters: New York, NY
+Products/Services: Develops technology and products for next-generation advanced robotic and spacecraft systems that must operate in increasingly dynamic, unstructured and often hostile environments.
+
+
+
+HONEYWELL INTERNATIONAL INC.
+4700 Innovation Drive, Suite A
+Fort Collins, CO 80525
+970-204-6121
+www.honeywell.com
+Company headquarters: Morristown, NJ
+Products/Services: Honeywell is a diversified technology and manufacturing company that serves the aerospace industry. It also provides control technologies for buildings, homes and industry.
+
+
+
+HYTEK ELECTRONIC DESIGN
+3161 Meadowbrook Place
+Dacono, CO 80514
+303-548-1534
+www.hytek-ed.com
+Company headquarters: Dacono
+Products/Services: Provides a wide range of electronic design services including Schematic Capture, PCB Layout, & Altera / Xilinx FPGA Design.
+Person in charge: Justin Kozlowitz, president
+
+
+INFINITY SYSTEMS ENGINEERING LLC
+13560 Northgate Estates Drive
+Colorado Springs, CO 80921
+719-548-9712
+www.infinity.aero
+Company headquarters: Colorado Springs
+Products/Services: Provides advisory, engineering, intelligence and information technology services for the government sector. Works on various DoD space systems, including satellite operations and maintenance.
+
+
+
+INGENICOMM INC.
+3242 Glendevey Drive
+Loveland, CO 80538
+970-430-9712
+www.ingenicomm.net
+Company headquarters: Chantilly, VA
+Products/Services: Provides key engineering development and field operations for satellite ground systems and telemetry products.
+
+
+
+INSTAR ENGINEERING & CONSULTING INC.
+6901 S. Pierce St., Suite 200
+Littleton, CO 80128
+303-973-2316
+www.instarengineering.com
+Company headquarters: Littleton
+Products/Services: Provides structural, mechanical and systems engineering, consulting and short courses in the aerospace industry.
+Person in charge: Thomas P. Sarafin, president, chief engineer
+
+
+INTEGRATED SPACEFLIGHT SERVICES LLC
+3360 Mitchell Lane, Suite C
+Boulder, CO 80301
+888-520-2050
+www.integratedspaceflight.com
+Company headquarters: Boulder
+Products/Services: Provides system engineering and project management expertise for manned spaceflight. Specializes in contingency mission analyses and rescue and recovery tests and trade studies.
+
+
+
+INTELLIPROP INC.
+105 S. Sunset St., Suite N
+Longmont, CO 80501
+303-774-0535
+www.intelliprop.com
+Company headquarters: Longmont
+Products/Services: Provider of SATA, SAS and RAID-based IP cores, bridges, port multipliers. ASIC and FPGA customized designs. Provider of SSD chip.
+Person in charge: Ami Patel, general manager
+
+
+INTREX AEROSPACE
+12777 Claude Court
+Thornton, CO 80241
+303-665-1154
+www.intrexcorp.com
+Company headquarters: Lansing, MI
+Products/Services: CNC machining, turning and milling for the aerospace industry.
+Person in charge: LaVonda Jeffrey, president
+
+
+JETTECH
+11757 W. Ken Caryl Ave., Suite F-503
+Littleton, CO 80127
+303-697-4262
+www.jettechllc.net
+Company headquarters: Littleton
+Products/Services: Instrumentation, sales and maintenance of aircraft systems.
+
+
+
+JETTECH — AVIONICS FACILITY
+10122 Airport Court
+Broomfield, CO 80021
+303-635-0055
+www.jettechllc.net
+Company headquarters: Littleton
+Products/Services: Instrumentation and maintenance of aircraft systems.
+
+
+
+KEVRON INC.
+3199 Billington Drive
+Erie, CO 80516
+720-226-0553
+www.kevron.com
+Company headquarters: Broomfield
+Products/Services: Designs, manufactures and sells laser marking systems for marking and asset tracking. Contract laser marking services.
+Person in charge: Ron Quinlan, co-owner, Kevin Warman, co-owner, co-owners
+
+
+KRATOS TECHNOLOGY AND TRAINING SOLUTIONS
+985 Space Center Drive
+Colorado Springs, CO 80915
+719-550-3430
+www.kratosdefense.com
+Company headquarters: Lanham, MD
+Products/Services: Provides ground systems to track and control satellites and to process and analyze the gathered information.
+
+
+
+LABORATORY FOR ATMOSPHERIC AND SPACE PHYSICS (LASP)
+1234 Innovation Drive
+Boulder, CO 80303-7814
+303-492-6412
+lasp.colorado.edu
+Company headquarters: Boulder
+Products/Services: Planetary, atmospheric and space sciences research; engineering division designs and builds space flight hardware; mission operations division operates spacecrafts.
+Person in charge: Daniel Baker, director
+
+
+LARSON ENGINEERING
+1006 Lee Hill Drive
+Boulder, CO 80302
+303-449-9292
+
+Company headquarters: Boulder
+Products/Services: Precision machine shop, prototype and production, mechanical engineering services, Pro Engineering-CREO CAD/CAM software.
+Person in charge: Rich Larson, owner
+
+
+LEFT HAND DESIGN CORP.
+2021 Miller Drive
+Longmont, CO 80501
+303-652-2786
+www.lefthand.com
+Company headquarters: Longmont
+Products/Services: Precision positioning components: fine-steering mirrors, faststeering mirrors, active isolation systems, motion simulators, linear electro-magnetic actuators, pointing systems.
+Person in charge: Lawrence Germann, president
+
+
+LOCKHEED MARTIN INTEGRATED SYSTEMS & SOLUTIONS
+6304 Spine Road
+Boulder, CO 80301
+303-581-4200
+www.lockheedmartin.com
+Company headquarters: Bethesda, Md.
+Products/Services: A systems integrator and information-technology company conducting business mainly with the U.S. Department of Defense and U.S. federal government agencies.
+Person in charge: Marillyn A. Hewson, CEO/president
+
+
+MANES MACHINE INC.
+2421 International Blvd.
+Fort Collins, CO 80524
+970-224-3311
+www.manesmachine.com
+Company headquarters: Fort Collins
+Products/Services: Offers precision machined products for aerospace, automotive, semiconductor and oil industries.
+
+
+
+MEADOWLARK OPTICS INC.
+5964 Iris Parkway
+Frederick, CO 80530
+303-833-4333
+www.meadowlark.com
+Company headquarters: Frederick
+Products/Services: Optical components/systems: spatial light modulators, waveplates, liquid crystal devices, tunable filters, polarizers, polarimeters, pockels cells, as well as custom fabrication & engineering.
+Person in charge: Garry Gorsuch
+
+
+MICROELECTRONICS RESEARCH DEVELOPMENT CORP.
+4775 Centennial Blvd., Suite 130
+Colorado Springs, CO 80919
+719-531-0805
+www.micro-rdc.com
+Company headquarters: Colorado Springs
+Products/Services: Radiation Hardened by Design, low power and high performance microcontrollers, serial to parallel interface, scrubber and digital Application Specific Integrated Circuits and testing services.
+Person in charge: Joe Cuchiaro, president
+
+
+MILLER SPACE LLC
+10131 Coronado Circle
+Morrison, CO 80465
+303-437-4198
+www.miller-space.com
+Company headquarters: Morrison
+Products/Services: Provides mechanical design-engineering services to the aerospace industry.
+Person in charge: Roger Miller, president
+
+
+MORGAN TECHNOLOGIES INC.
+8101 I-25 Frontage Road, Unit 4
+Erie, CO 80516
+303-651-1990
+
+Company headquarters: Erie
+Products/Services: Manufacturer of aerospace parts. Medical, research companies.
+Person in charge: Bill Morgan, president
+
+
+NATIONAL TECHNICAL SYSTEMS INC.
+1736 Vista View Drive
+Longmont, CO 80504
+303-776-7249
+www.nts.com
+Company headquarters: Longmont
+Products/Services: Certified full-compliance electro magnetic emissions and immunity testing. MIL-STD 461 testing.
+Person in charge: Patrick Conway , operations manager, Scott D. Dalgleish, CEO/president
+
+
+NEW VISTA RESEARCH INC.
+630 North St.
+Boulder, CO 80305
+720-288-0506
+www.newvistaresearch.com
+Company headquarters: Boulder
+Products/Services: Research consulting, engineering consulting, computer modeling, information services; aerospace, mechanical, chemical, physics, bioengineering.
+Person in charge: Rom McGuffin, senior scientist
+
+
+PLANETIQ
+2425 55th St., Suite A-150
+Boulder, CO 80301
+571-364-7238
+www.planetiq.com
+
+Products/Services: Commercial weather satellite constellations; numerical weather prediction data; weather forecasting products, services and analytics.
+
+
+
+NORTHROP GRUMMAN MISSION SYSTEMS INC.
+6120 Longbow Drive
+Boulder, CO 80301
+720-622-6008
+www.ngc.com
+Company headquarters: Baltimore, MD
+Products/Services: Satellite ground stations supporting missile warning and missile defense.
+Person in charge: Ron Alford, director, overhead persistent IR exploitation systems
+
+
+PARADIGM RESEARCH OPTICS
+595 W. 66th St.
+Loveland, CO 80538
+970-776-8900
+www.research-optics.com
+Company headquarters: Loveland
+Products/Services: Thin film coating, UV-MWIR, thin film design, lens design, lens fabrication, array of shapes, sizes and specifications. Optical assemblies and subassemblies, turn key optics, optical system I.
+Person in charge: Matt Morgan
+
+
+PARAVION TECHNOLOGY INC.
+2001 Airway Ave.
+Fort Collins, CO 80524
+970-224-3898
+www.paravion.com
+Company headquarters: Fort Collins
+Products/Services: Designs and manufactures aircraft accessories for the general aviation marketplace.
+
+
+
+PETERSON MACHINING INC.
+6661 Arapahoe Road, Unit 6
+Boulder, CO 80303
+303-449-5755
+www.gotopmi.com
+Company headquarters: Boulder
+Products/Services: Precision machine shop.
+Person in charge: Ronda Turner Peterson, CEO, owner
+
+
+PHASE IV ENGINEERING INC.
+2820 Wilderness Place, Unit C
+Boulder, CO 80301
+303-443-6611
+www.phaseivengr.com
+Company headquarters: Boulder
+Products/Services: Develop, make, and sell wireless sensors: battery-free wireless RFID sensors, long-range battery-powered sensors, and wireless data loggers. Offer off-the shelf products and custom wireless sensors.
+
+
+
+PILATUS BUSINESS AIRCRAFT
+11755 Airport Way
+Broomfield, CO 80021
+303-438-5965
+www.pilatus-aircraft.com
+Company headquarters: Broomfield
+Products/Services: Aircraft company.
+Person in charge: Thomas Bosshard
+
+
+PLEXUS
+285 Century Place, Suite 100
+Louisville, CO 80027
+303-926-9449
+www.plexus.com
+Company headquarters: Neenah, Wis.
+Products/Services: Provides integrated product development manufacturing and sustaining services for Healthcare/Life Sciences, Industrial/Commercial, Networking/Communications & Defense/Security/Aerospace products.
+
+
+
+POUDRE AVIATION INC.
+621 Ed Beegles Lane
+Greeley, CO 80631
+970-378-8994
+www.poudreaviation.com
+
+
+
+
+
+PRECISION MACHINED PRODUCTS LLC.
+1017 Smithfield Drive
+Fort Collins, CO 80524
+970-482-7676
+www.pmpmach.com
+Company headquarters: Fort Collins
+Products/Services: Close-tolerance machined parts for aerospace, satellite, space, and defense.
+Person in charge: Andy Newcomb, president
+
+
+RAPIDPRO MANUFACTURING CORP.
+30 E. Ninth Ave.
+Longmont, CO 80504
+970-535-0550
+www.rapidpro.com
+Company headquarters: Longmont
+Products/Services: Product design, prototype parts, cast urethane parts, metal coatings, tooling/injection molding and contract manufacturing.
+Person in charge: Ron Angstead
+
+
+REDSTONE AEROSPACE CORP.
+105 S. Sunset St., Unit T
+Longmont, CO 80501
+303-684-8125
+www.redstoneaerospace.com
+Company headquarters: Longmont
+Products/Services: Provides cryogenic systems, opto-mechanical systems, and precision mechanisms for the aerospace industry.
+Person in charge: Robert Levenduski, president
+
+
+RESEARCH ELECTRO-OPTICS INC.
+5505 Airport Blvd.
+Boulder, CO 80301
+303-938-1960
+www.reoinc.com
+Company headquarters: Boulder
+Products/Services: Produces high-precision thin film coatings, optics and opto-mechanical assemblies for the ulatraviolet, visible and infrared.
+Person in charge: Paul Kelly
+
+
+ROCKY MOUNTAIN INSTRUMENT CO.
+106 Laser Drive
+Lafayette , CO 80026
+303-664-5000
+www.rmico.com
+
+
+
+
+
+SCION UAS LLC
+3693 E. County Road 30
+Fort Collins, CO 80528
+970-624-3560
+www.scionuas.com
+Company headquarters: Fort Collins
+Products/Services: Vertical take-off and landing (VTOL) unmanned aerial systems.
+Person in charge: Mogensen Steen, CEO
+
+
+SEAKR ENGINEERING INC.
+500 Discovery Pkwy #200
+Superior, CO 80027
+303-662-1449
+www.seakr.com
+
+
+
+
+
+SIERRA NEVADA CORP. SPACE SYSTEMS
+1722 Boxelder St.
+Louisville, CO 80027
+303-530-1925
+www.sncspace.com
+Company headquarters: Sparks, NV
+Products/Services: Supplies space technologies & advanced spacecraft for civil, commercial & national security applications.
+
+
+
+SOLID POWER INC.
+500 S. Arthur Ave., Unit 300
+Louisville, CO 80027
+720-300-8167
+www.solidpowerbattery.com
+Company headquarters: Louisville, CO
+Products/Services: A CU-Boulder spin-out business, Solid Power develops solid-state rechargeable batteries. Target markets include automotive, consumer electronics, aerospace and military.
+Person in charge: Douglas Campbell, president & CEO
+
+
+SPACENAV
+2727 Bryant St., Suite 540
+Denver, CO 80211
+719.433.1692
+www.space-nav.com
+
+Products/Services: Applied mathematics and aerospace engineering.
+
+
+
+SPECIAL AEROSPACE SERVICES LLC
+3005 30th St.
+Boulder, CO 80301
+303-625-1010
+www.specialaerospaceservices.com
+
+Products/Services: Engineering services for spaceflight safety, technical services, systems engineering and hardware development and precision manufacturing.
+
+
+
+SPORIAN MICROSYSTEMS INC.
+515 Courtney Way, Suite B
+Lafayette, CO 80026
+303-516-9075
+www.sporian.com
+Company headquarters: Lafayette
+Products/Services: Provides novel sensors, microelectromechanical systems (MEMS) design and packaging services.
+Person in charge: Michael Usrey, vice president
+
+
+ST. VRAIN MANUFACTURING INC.
+819 S. Lincoln St.
+Longmont, CO 80501
+303-702-1529
+www.stvrainmfg.com
+Company headquarters: Longmont
+Products/Services: Precision machining for aerospace, medical and high-tech industries. 3, 4 and 5-Axis CNC Milling, CNC turning, wire EDM. Quality system based on AS-9100 Zeiss/B&S CMMs ITAR Registered.
+Person in charge: Bob Bergstrom, president
+
+
+STEMGIRLS LLC
+509 London Ave.
+Lafayette, CO 80026
+303-817-6369
+
+Company headquarters: Lafayette
+Products/Services: Hands-on STEM workshops for girls ages 7-12. Lead exclusively by female role models. STEMgirls is offered once a month at the Louisville Recreation Center.
+Person in charge: Karen Alfino, Founder/CEO
+
+
+STRATOM INC.
+5375 Western Ave., Suite A
+Boulder, CO 80301
+720-565-9609
+www.stratom.com
+Company headquarters: Boulder
+Products/Services: Strategic solutions, advanced technologies and services to government, commercial and global clients. Specializing in C-IED, robotics, unmanned vehicles, sensor integration and engineering.
+Person in charge: Mark Gordon, president/CEO
+
+
+STRIKEWIRE TECHNOLOGIES
+149 S. Briggs St., Suite 102A
+Erie, CO 80516-4065
+
+www.strikewire.com
+Company headquarters: Erie, CO
+Products/Services: Product-lifescycle management services for the aerospace, medical-device, automotive, electronics and other sectors.
+
+
+
+TECHNOLOGY APPLICATIONS INC.
+5710 Flatiron Parkway, Unit A
+Boulder, CO 80301
+303-867-8145
+www.techapps.com
+Company headquarters: Boulder
+Products/Services: Cryogenic and thermal management systems research and development for aerospace and commercial applications. Primary focus on thermal straps for satellites and microsphere cryogenic insulation.
+
+
+
+TEMPERATURE PROCESSING CO. INC.
+10477 Weld County Road 7
+Longmont, CO 80504
+303-772-0250
+www.tpcolorado.com
+Company headquarters: Longmont
+Products/Services: Certified aerospace, medical, nuclear, mil-spec and custom heat treating.
+Person in charge: Eric Engelhard, Steward
+
+
+THE AEROSPACE CORP.
+7250 Getting Heights
+Colorado Springs, CO 80916
+719-375-6000
+www.aero.org
+Company headquarters: El Segundo, CA
+Products/Services: Federally funded research and development center; advises the DoD on all aspects of satellite acquisition, launch and operation.
+
+
+
+TWIN OAKS COMPUTING
+755 Maleta Lane, Suite 203
+Castle Rock, CO 80108
+720-733-7906
+
+Company headquarters: Castle Rock
+Products/Services: Developer of CoreDX DDS, a Publish-Subscribe middleware available for small-footprint and embedded systems.
+Person in charge: Clark Tucker
+
+
+U.S. AIR FORCE ACADEMY RESEARCH CENTERS AND INSTITUTES (USAFA)
+2354 Fairchild Drive, Suite 4K25
+USAF Academy, CO 80840-6200
+719-333-7731
+www.usafa.af.mil
+Company headquarters: Colorado Springs
+Products/Services: The Academy’s research mission is to plan and execute research programs in Air Force-relevant technology. This includes basic and applied research in aeronautics, biomimetic sensors, nanosatellites.
+Person in charge: Robert Kraus, chief scientist
+
+
+UASUSA
+East Hangar, 229 Airport Road
+Longmont, CO 80503
+720-608-1827
+www.uasusa.com
+Company headquarters: Longmont
+Products/Services: Develops and sells small civilian unmanned aerial systems (UAS) that help governments, businesses and nongovernmental organizations resolve some of society’s biggest challenges.
+
+
+
+VIASAT INC.
+349 Inverness Drive South
+Englewood, CO 80112
+888-746-8960
+www.viasat.com
+Company headquarters: Englewood
+Products/Services: Produces satellite and other digital communication products.
+
+
+
+WOODWARD INC.
+1081 Woodward Way
+Fort Collins, CO 80524
+970-482-5811
+www.woodward.com
+Company headquarters: Fort Collins
+Products/Services: Components and systems that enable energy control, efficient operations and lower emissions in large industrial engines.
+Person in charge: Thomas A. Gendron, CEO
+
+
+WOODWARD INC.
+1000 E. Drake Road
+Fort Collins, CO 80525-1824
+970-482-5811
+www.woodward.com
+Company headquarters: Fort Collins
+Products/Services: Components and systems that enable energy control, efficient operations and lower emissions in large industrial engines.
+Person in charge: Thomas A. Gendron, CEO/chairman
+
+
+WOODWARD INC.
+3800 Wilson Ave.
+Loveland, CO 80538
+970-482-5811
+www.woodward.com
+Company headquarters: Fort Collins
+Products/Services: Components and systems that enable energy control, efficient operations and lower emissions in large industrial engines.
+Person in charge: Thomas A. Gendron, CEO/chairman

--- a/data/test_fixtures_data/agricultural_technology.txt
+++ b/data/test_fixtures_data/agricultural_technology.txt
@@ -1,0 +1,218 @@
+ADVANCED REGENERATIVE THERAPIES
+320 E. Vine Drive, Suite 122
+Fort Collins, CO 80524
+970-222-9831
+www.art4dvm.com
+Company headquarters: Fort Collins
+Products/Services: Uses stem cells derived from the bone marrow of equine and canine to treat equine athlete joint injuries.
+Person in charge: Cristin Keohan, laboratory director
+
+
+AGRIUM U.S. INC.
+3005 Rocky Mountain Ave.
+Loveland, CO 80538
+970-685-3300
+www.agrium.com/
+Company headquarters: Calgary, Alberta
+Products/Services: One of the largest global distributors of fertilizer, producing and marketing 10.8 million tons of nitrogen, phosphate and potash.
+
+
+
+AGRIUM WHOLESALE TECHNICAL CENTER
+2323 115th Ave.
+Greeley, CO 80634
+970-685-3300
+www.agrium.com/
+Company headquarters: Calgary, Alberta
+Products/Services: Agricultural research facility.
+
+
+
+ANIMARK INC.
+876 Ventura St.
+Aurora, CO 80011
+303-343-8342
+www.animark.us
+Company headquarters: Aurora
+Products/Services: Manufactures high-tech livestock breeding equipment.
+
+
+
+ATLAS BIOLOGICALS INC.
+2649 E. Mulberry St., Suite A-3
+Fort Collins, CO 80524
+866-222-8988
+www.atlasbio.com
+Company headquarters: Fort Collins
+Products/Services: Fetal bovine serum.
+
+
+
+AWHERE INC.
+2655 W. Midway Blvd., Suite 235
+Broomfield, CO 80020
+303-279-9293
+www.awhere.com
+Company headquarters: Broomfield
+Products/Services: Collects and analyses more than a billion points of data from around the globe each day to create agricultural intelligence.
+Person in charge: John Corbett, president, CEO
+
+
+CARGILL INC. SPECIALTY SEEDS AND OILS INNOVATION CENTER
+2410 E. Drake Road
+Fort Collins, CO 80525
+970-482-8818
+www.cargill.com
+Company headquarters: Minneapolis, MN
+Products/Services: Focuses on specialty canola hybrid development.
+
+
+
+CROP PRODUCTION SERVICES INC.
+3005 Rocky Mountain Ave.
+Loveland, CO 80538
+970-685-3300
+www.cpsagu.com
+Company headquarters: Calgary, Alberta, Canada
+Products/Services: Agricultural cropprotection chemicals and nutritionals.
+Person in charge: Richard Gearheard, CEO
+
+
+DAIRY TECH INC.
+34824 Weld County Road 29
+Greeley, CO 80631
+970-674-1888
+www.dairytechinc.com
+Company headquarters: Severance
+Products/Services: Development, manufacture and sales of pasteurizers for improved dairy bio-security.
+
+
+
+EVOLUTIONARY GENOMICS INC.
+1026 Anaconda Drive
+Castle Rock, CO 80108
+720-900-8666
+www.evolgen.com
+Company headquarters: Castle Rock
+Products/Services: A genetic information discovery company, utilizing sophisticated gene sequencing technologies, targeting neural/behavioral science diseases and disorders
+Person in charge: Walter Messier, founder/CTO
+
+
+EVOLUTIONARY GENOMICS INC.
+1801 Sunset Place, Suite C
+Longmont, CO 80501
+303-862-3222
+www.evolgen.com
+Company headquarters: Castle Rock
+Products/Services: A genetic information discovery company, utilizing sophisticated gene sequencing technologies, targeting neural/behavioral science diseases and disorders
+Person in charge: Walter Messier, founder/CTO
+
+
+OPTIBRAND LTD. LLC
+300 Boardwalk Drive, Suite 1B
+Fort Collins, CO 80525
+970-490-6022
+www.optibrand.com
+Company headquarters: Fort Collins
+Products/Services: Portable, biometric identification and diagnostic cameras.
+
+
+
+STEMGIRLS LLC
+509 London Ave.
+Lafayette, CO 80026
+303-817-6369
+
+Company headquarters: Lafayette
+Products/Services: Hands-on STEM workshops for girls ages 7-12. Lead exclusively by female role models. STEMgirls is offered once a month at the Louisville Recreation Center.
+Person in charge: Karen Alfino, Founder/CEO
+
+
+SUMMIT PLANT LABORATORIES INC.
+3003 W. Vine Drive
+Fort Collins, CO 80521
+970-224-2021
+www.plantlabs.com
+Company headquarters: Fort Collins
+Products/Services: Wholesale specialty micropropagation and seed-health business.
+Person in charge: Tom Smith, president
+
+
+FLATIRONS TECHNOLOGY GROUP
+1942 Broadway, Suite 50
+Boulder, CO 80302
+303-378-4847
+www.coftg.com
+Company headquarters: Boulder
+Products/Services: Technology consulting for cyber and physical security, building and agricultural automation.
+Person in charge: Marc Ginsberg, president
+
+
+THE AQUAPONIC SOURCE
+1860 Lefthand Circle, Suite E
+Longmont, CO 80501
+303-720-6604
+www.theaquaponicsource.com
+Company headquarters: Longmont
+Products/Services: Manufacture products related to aquaponic gardening.
+Person in charge: Sylvia Bernstein, owner
+
+
+HYDROBIO INC.
+1700 Lincoln St., 29th Floor
+Denver, CO 80203
+720-295-9285
+hydrobioars.com
+Company headquarters: Denver
+Products/Services: An agricultural technology company that develops proprietary software and process that could revolutionize agricultural irrigation.
+
+
+
+TIMBERLINE INSTRUMENTS LLC
+1880 S. Flatiron Court, Suite 1
+Boulder, CO 80301
+303-440-8779
+www.timberlineinstruments.com
+Company headquarters: Boulder
+Products/Services: Manufactures ammonia and nitrite analyzers, HPLC column heaters and mobile phase pre-heaters.
+
+
+
+KEETON INDUSTRIES INC.
+1520 Aquatic Drive
+Wellington, CO 80549
+970-568-7754
+www.keetonaquatics.com
+Company headquarters: Wellington
+Products/Services: Biological remediation products for recreational pond and lakes, wastewater-treatment facilities and fish farms.
+Person in charge: Jim Keeton, founder/president
+
+
+USDA AGRICULTURAL SYSTEMS RESEARCH UNIT (ASRU)
+2150 Centre Ave., Building D, Suite 200
+Fort Collins, CO 80526
+970-492-7300
+www.ars.usda.gov
+Company headquarters: Fort Collins
+Products/Services: ASRU exists to provide leadership in systems research for developing sustainable and adaptive integrated agricultural systems.
+Person in charge: Laurence Chandler, area director
+
+
+USDA CENTRAL GREAT PLAINS RESEARCH STATION
+40335 County Road GG
+Akron, CO 80720
+970-345-2259
+www.ars.usda.gov
+Company headquarters: Akron
+Products/Services: Enhances the economic and environmental well-being of agriculture by development of integrated cropping systems and technologies for maximum utilization of soil and water resources.
+Person in charge: Merel F. Vigil, research leader/soil scientist
+
+
+ZEOPONIX INC.
+P.O. Box 19105
+Boulder, CO 80308
+303-673-0098
+www.zeoponix.com
+Company headquarters: Boulder
+Products/Services: Zeoponic soil amendment/fertilizer, NASA spin off, high efficiency ion exchange nutrient delivery; horticulture, sports/golf, forestry, agriculture, landscaping, greenroofs, aquaponics, reclamation.
+Person in charge: Richard Andrews, CEO

--- a/data/test_fixtures_data/association_technology.txt
+++ b/data/test_fixtures_data/association_technology.txt
@@ -1,0 +1,808 @@
+ADAMS COUNTY ECONOMIC DEVELOPMENT
+12050 Pecos St.
+Westminster, CO 80234
+303-450-5103
+www.adamscountyed.com
+Company headquarters: Westminster
+Products/Services: We help companies relocate, expand, start-up, find incentives, and act as an advocate for businesses in Adams
+County, focusing on optics, photonics, and biotechnology.
+Person in charge: Barry Gore
+
+AIM
+7900 E. Union Ave.
+Denver, CO 80237
+303-249-0081
+aimforbrilliance.org
+Company headquarters: Denver
+Products/Services: Not-for-profit community organization that promotes technology to empower people, enhance organizations and create brilliant communities.
+
+
+
+ALLIANCE FOR SUSTAINABLE COLORADO
+1536 Wynkoop St.
+Denver, CO 80202
+303-572-1536
+www.sustainablecolorado.org
+Company headquarters: Denver
+Products/Services: Promotes innovation in renewable energy.
+
+
+
+AMICUS SOLAR COOPERATIVE
+4571 Broadway
+Boulder, CO 80304
+303-261-2898
+www.amicussolar.com
+Company headquarters: Boulder
+Products/Services: A solar-purchasing cooperative that is jointly owned and democratically managed by member companies.
+Person in charge: Stephen Irvin, president
+
+
+ARAPAHOE COUNTY GOVERNMENT
+5334 S. Prince St.
+Littleton, CO 80120
+303-795-4460
+www.arapahoegov.com
+Company headquarters: Littleton
+Products/Services: Colorado’s first county, founded in 1861, is home to 607,000 citizens and 13 municipalities. The county provides
+Human Services, elections, public safety, public works and open spaces to citizens.
+Person in charge: Nancy A. Doty, county commissioner, Nancy N. Sharpe, county commissioner, Rod Bockenfeld, county commissioner, Nancy Jackson, county commissioner, Bill L. Holen, county commissioner, county commissioners
+
+ARAPAHOE/DOUGLAS WORKS! WORKFORCE CENTER
+6974 S. Lima St.
+Centennial, CO 80112
+303-636-1210
+www.adworks.org/
+Company headquarters: Arapahoe
+Products/Services: Workforce development.
+Person in charge: Joe Barela, Director
+
+
+ASSOCIATION OF INFORMATION TECHNOLOGY PROFESSIONALS — COLORADO CHAPTER
+1120 Route 73, Suite 200
+Mount Laurel, NJ 08054
+800-224-9371
+www.aitpmilehigh.org
+Company headquarters: Mount Laurel, NJ
+Products/Services: Seeks to advance the IT profession through professional development, support of IT education and national policies on IT that improve society.
+
+
+
+BETTER BUSINESS BUREAU OF DENVER/BOULDER
+3801 E. Florida Ave.
+Denver, CO 80210
+303-758-2100
+www.bbb.org/denver
+Company headquarters: Denver
+Products/Services: Promotes and fosters the highest ethical relationships between businesses and the public through voluntary self-regulation.
+Person in charge: Su Hawk, President/CEO
+
+
+BIOTECHNOLOGY INDUSTRY ORGANIZATION
+1201 Maryland Ave. SW, Suite 900
+Washington, DC 20024
+202-962-9200
+www.bio.org
+Company headquarters: Washington, D.C.
+Products/Services: BIO is the world’s largest trade association representing biotechnology companies, academic institutions, state biotechnology centers and related organizations across the United States.
+
+
+
+BOULDER CHAMBER
+2440 Pearl St.
+Boulder, CO 80302
+303-442-1044
+www.boulderchamber.com
+Company headquarters: Boulder
+Products/Services: Networking opportunities, educational programs, business advocacy support.
+Person in charge: John Tayer, CEO, president
+
+
+BOULDER ECONOMIC COUNCIL
+2440 Pearl St.
+Boulder, CO 80302
+303-786-7567
+www.bouldereconomiccouncil.org
+Company headquarters: Boulder
+Products/Services: The Boulder Economic Council is the economic-development arm of the Boulder Chamber.
+Person in charge: Clif Harald, Executive Director
+
+
+BOY SCOUTS OF AMERICA
+10455 W. Sixth Ave.
+Denver, CO 80215
+303-455-5522
+www.stemscouts.org/denver
+Products/Services: STEM Scouts is a national pilot program from the Boy Scouts of America, focused on fun ways for girls and boys, grades 3 - 12, to learn more about science, technology, engineering and mathematics (STEM).
+
+
+
+
+BRIGHTON ECONOMIC DEVELOPMENT CORP.
+22 S. Fourth Ave., Suite 305
+Brighton, CO 80601
+303-655-2155
+www.brightonedc.org
+Company headquarters: Brighton
+Products/Services: Public/private partnership designed to assist new and existing businesses in Brighton. Attraction, site selection, retention, expansion, entrepreneurism, workforce and education.
+Person in charge: Robert Smith, CEO, president
+
+
+BROOMFIELD WORKFORCE
+100 Spader Way
+Broomfield, CO 80020
+303-464-5855
+www.broomfieldworkforce.org
+Company headquarters: Broomfield
+Products/Services: A service of the city and county of Broomfield. Provides free services to assist employers and job seekers alike.
+
+
+
+BUILT IN COLORADO
+1062 Delaware St.
+Denver, CO 80204
+303-823-4170
+www.builtincolorado.com
+Company headquarters: Chicago
+Products/Services: A rapidly growing network that offers the number one job board for digital tech talent. Publishes data on the digital tech sector of Colorado and produces engaging monthly events.
+Person in charge: Maria Katris
+
+
+BUSINESS INCUBATOR CENTER
+2591 Legacy Way
+Grand Junction, CO 81503-1789
+970-243-5242
+www.gjincubator.org
+Company headquarters: Grand Junction
+Products/Services: Business training and education.
+
+
+
+CABLELABS
+858 Coal Creek Circle
+Louisville, CO 80027
+303-661-9100
+www.cablelabs.com
+Company headquarters: Louisville
+Products/Services: Technology research and development.
+Person in charge: Phil McKinney, president/CEO
+
+
+CATALYST CAMPUS FOR TECHNOLOGY AND INNOVATION
+555 Pikes Peak Ave.
+Colorado Springs, CO 80903
+719-896-5087
+www.catalystcampus.com
+Company headquarters: Colorado Springs
+Products/Services: Occupational acceleration: Crafts relevant training curriculum that responds to workforce needs of Southern
+Colorado technology companies. R&D:
+Provides partners, labs and exercise environments.
+
+CENTER FOR THE NEW ENERGY ECONOMY
+Powerhouse Energy Campus, 430 N. College Ave.
+Fort Collins, CO 80524
+970-491-2903
+www.cnee.colostate.edu
+Company headquarters: Fort Collins
+Products/Services: Headed by former
+Gov. Rill Ritter, CNEE works with governors, legislators, regulators, companies and stakeholders to help create policies that facilitate the transition to a clean-energy economy.
+
+
+CITY OF AURORA
+15151 E. Alameda Parkway
+Aurora, CO 80012
+www.auroragov.org
+Company headquarters: Aurora
+Products/Services: City government.
+
+
+
+
+CITY AND COUNTY OF DENVER OFFICE OF ECONOMIC DEVELOPMENT
+201 W. Colfax Ave.
+Denver, CO 80202
+720-913-1999
+www.milehigh.com
+Company headquarters: Denver
+Products/Services: OED promotes job creation, business assistance, housing options, neighborhood redevelopment and the development of a skilled workforce in Denver.
+
+
+
+CITY & COUNTY OF DENVER — TECHNOLOGY SERVICES
+201 W. Colfax Ave.
+Denver, CO 80202
+www.denvergov.org
+Company headquarters: Denver
+Products/Services: Provides centralized IT support to more than 11,000 employees and
+600,000+ citizens. Also runs the City 311
+Call Center and Denver 8 television channel.
+
+
+CITY OF WESTMINSTER
+4800 W. 92nd Ave.
+Westminster, CO 80031
+303-658-2108
+www.cityofwestminster.us
+Company headquarters: Westminster
+Products/Services: City government. Westminster is home to more than 200 software/IT businesses.
+
+
+
+COLLEGE IN COLORADO
+1560 Broadway
+Denver, CO 80202
+720-264-8560
+secure.collegeincolorado.org
+Company headquarters: Denver
+Products/Services: College in Colorado was initiated by the Department of Higher Education to promote access to, affordability of and success in higher education for all students.
+Person in charge: Dawn Taylor, executive director
+
+
+COLORADO ADVANCED MANUFACTURING ALLIANCE
+14062 Denver West Parkway, Building 52, Suite 300
+Golden, CO 80401
+800-680-8820
+co-cama.org
+Company headquarters: Colorado
+Products/Services: The organization advances manufacturing in Colorado.
+Person in charge: Tim Heaton, president
+
+
+COLORADO BIOSCIENCE ASSOCIATION
+600 Grant St., Suite 306
+Denver, CO 80203
+303-592-4073
+www.cobioscience.com
+Company headquarters: Denver
+Products/Services: Nonprofit representing more than 350 member organizations, CBSA is the hub of Colorado’s bioscience sector, connecting innovators to resources and leading policy initiatives to accelerate growth.
+Person in charge: April Giles, president/CEO
+
+
+COLORADO CLEAN ENERGY CLUSTER
+PO Box 272410
+Fort Collins, CO 80527
+720-593-0058
+www.coloradocleanenergy.com
+Company headquarters: Fort Collins
+Products/Services: Nonprofit, clean energy project coordination.
+Person in charge: Tom Ghidossi, Co-Chair, Board of Directors
+Ed VanDyne, Co-Chair, Board of Directors, Co-Chair, Board of Directorss
+
+COLORADO CLEANTECH INDUSTRY ASSOCIATION
+14062 Denver West Parkway, Building 52, Suite 300
+Golden, CO 80401
+720-274-9777
+www.coloradocleantech.com
+Company headquarters: Golden
+Products/Services: Represents the interests of the state’s cleantech industry.
+Person in charge: Chris Shapard, executive director
+
+
+COLORADO DEPARTMENT OF EDUCATION
+1535 Grant St., Room 207
+Denver, CO 80203
+303-866-6600
+www.cde.state.co.us
+Company headquarters: Denver
+Products/Services: CDE supports the advancement and improvement of the state’s education system.
+Person in charge: Violeta Garcia, education coordinator
+
+
+COLORADO DEPARTMENT OF HUMAN SERVICES
+1200 Federal Blvd.
+Denver, CO 80204
+303-866-5700
+www.colorado.gov/cs/Satellite/CDHS-Main/CBON/1251575083520
+Company headquarters: Denver
+Products/Services: Designs and delivers human and health services for the people of
+Colorado.
+
+
+COLORADO INTERACTIVE
+600 17th St.
+Denver, CO 80202
+www.Colorado.gov
+Company headquarters: Denver
+Products/Services: Colorado Interactive is the government face for Colorado.gov, the official website of the State of Colorado.
+Colorado Interactive helps state and local government entities Web-enable their services and is operated without the use of tax funds. Colorado Interactive is a subsidiary of NIC, (NASDAQ: EGOV) a provider of official government portals, online services and secure payment processing solutions.
+
+
+
+COLORADO DEPARTMENT OF LABOR & EMPLOYMENT
+633 17th St., Suite 700
+Denver, CO 80202
+303-318-8822
+www.colorado.gov/cs/Satellite/CDLE-Main/CDLE/1240336821467
+Company headquarters: Denver
+Products/Services: Services for Colorado's labor force.
+
+
+
+COLORADO MESA
+Campus Box 104, P.O. Box 173364
+Denver, CO 80217
+303-556-8568
+www.mesausa.org
+Company headquarters: Denver
+Products/Services: Mission is to increase the numbers of economically disadvantaged and underrepresented students in colleges of engineering, math and science.
+Person in charge: Donna Burns, development director
+
+
+COLORADO OFFICE OF ECONOMIC DEVELOPMENT AND INTERNATIONAL TRADE (OEDIT)
+1625 Broadway, Suite 2700
+Denver, CO 80202
+303-892-3840
+www.advancecolorado.com
+Company headquarters: Denver
+Products/Services: Works with statewide partners to create a positive business climate that encourages dynamic economic development and sustainable job growth.
+Person in charge: Fiona Arnold, executive director
+
+
+COLORADO OFFICE OF INFORMATION TECHNOLOGY (OIT)
+601 E. 18th Ave., Suite 250
+Denver, CO 80202
+303-764-7723
+www.colorado.gov/oit
+Company headquarters: Denver
+Products/Services: Responsible for the operation and delivery of information and communications technology services and innovation across all Executive Branch agencies in Colorado.
+
+
+
+COLORADO OFFICE OF STATE PLANNING AND BUDGETING
+601 E. 18th Ave., Suite 250
+Denver, CO 80203
+303-809-6572
+www.colorado.gov/ospb
+Company headquarters: Denver
+Products/Services: OSPB provides the
+Governor with timely and complete information and recommendations so he can make sound public policy and budget decisions.
+
+
+COLORADO PHOTONICS INDUSTRY ASSOCIATION
+P.O. Box 700
+Boulder, CO 80306
+303-834-1022
+www.coloradophotonics.org
+Company headquarters: Boulder
+Products/Services: A not-for-profit organization that promotes the photonics industry inside and outside of the state of Colorado.
+Person in charge: Brian Knollenberg, president
+
+
+COLORADO SPRINGS REGIONAL BUSINESS ALLIANCE
+102 S. Tejon St., Suite 430
+Colorado Springs, CO 80903
+719-471-8183
+www.csrba.com
+Company headquarters: Colorado Springs
+Products/Services: Primary advocate of the Colorado Springs/Pikes Peak region business community, dedicated to serving businesses of all sizes to build regional economic growth through economic development efforts.
+Person in charge: Dirk Draper, President & CEO Al Wenstrand, Chief Economic Development Officer Tammy Fields, Senior VP, Economic Development
+
+
+COLORADO TECHNOLOGY ASSOCIATION
+1245 Champa St.
+Denver, CO 80204
+303-592-4070
+www.coloradotechnology.org
+Company headquarters: Denver
+Products/Services: A not-for-profit organization dedicated to advancing the technology industry.
+Person in charge: Andrea Young, CEO
+
+
+COLORADO TECHNOLOGY FOUNDATION
+1245 Champa St.
+Denver, CO 80204
+303-592-4070
+www.coloradotechnology.org/page/Foundation/?
+Company headquarters: Denver
+Products/Services: The foundation bridges companies in the technology sector to education, technology and workforce programs in
+Colorado.
+
+
+COLORADO WOMEN’S CHAMBER OF COMMERCE (CWCC)
+1350 17th St., Suite 100
+Denver, CO 80202
+303-458-0220
+www.cwcc.org
+Company headquarters: Denver
+Products/Services: Chamber of Commerce.
+
+
+
+DENVER ART MUSEUM
+100 W. 14th Ave. Parkway
+Denver, CO 80204
+www.denverartmuseum.org
+Company headquarters: Denver
+Products/Services: Educational, nonprofit resource that sparks creative thinking and expression through transformative experiences with art.
+
+
+
+
+DENVER CENTER FOR THE PERFORMING ARTS
+1101 13th St.
+Denver, CO 80204
+303-893-4000
+www.denvercenter.org
+Company headquarters: Denver
+Products/Services: Not-for-profit organization that serves the entire Rocky Mountain region with the arts programming and education.
+
+
+
+DENVER METRO CHAMBER OF COMMERCE
+1445 Market St.
+Denver, CO 80202
+303-534-8500
+www.denverchamber.org
+Company headquarters: Denver
+Products/Services: The voice of business in the Denver metro area, dedicated to economic vitality and quality of life.
+Person in charge: Kelly Brough, president/CEO
+
+
+DENVER SOUTH ECONOMIC DEVELOPMENT PARTNERSHIP
+304 Inverness Way South, Suite 315
+Englewood, CO 80112
+303-531-8372
+www.denversouthedp.org
+Company headquarters: Englewood
+Products/Services: Promotes economic development through business attraction and retention, workforce development and providing programs and services to support local businesses.
+Person in charge: Mike Fitzgerald, president/CEO
+
+
+DOUGLAS COUNTY
+100 Third St.
+Castle Rock, CO 80104
+www.douglas.co.us
+Company headquarters: Castle Rock
+Products/Services: County government.
+
+
+
+
+DOWNTOWN DENVER PARTNERSHIP
+511 16th St., Suite 200
+Denver, CO 80202
+303-571-8217
+www.downtowndenver.com
+Company headquarters: Denver
+Products/Services: Plans, manages and develops Downtown Denver. A membership organization comprised of businesses and civic leaders.
+Person in charge: Tami Door, CEO/president
+
+EDUCAUSE
+282 Century Place, Suite 5000
+Louisville, CO 80027
+303-449-4430
+www.educause.edu
+Company headquarters: Louisville, CO
+Products/Services: Helps those who lead, manage and use information technology to shape strategic IT decisions at every level
+within higher education.
+
+
+
+ENERGY AND MINERALS FIELD INSTITUTE
+Colorado School of Mines
+Gloden, CO 80401
+303-279-5563
+www.emfi.csmspace.com
+Company headquarters: Golden
+Products/Services: The Energy and Minerals Field Institute (EMFI), designs and conducts programs to familiarize selected audiences
+with the realities of resource development in the Western United States.
+
+
+GIS COLORADO
+2050 E. Iliff Ave.
+Denver, CO 80208-0001
+303-871-2535
+www.giscolorado.org/
+Company headquarters: Colorado
+Products/Services: GIS Colorado is a nonprofit organization represented by members of the GIS community throughout Colorado.
+Person in charge: Ben Sloboda, chair
+
+
+GLOBAL ACCELERATOR NETWORK
+1031 33rd St.
+Denver, CO 80205
+303-335-0728
+www.gan.co
+Company headquarters: Denver
+Products/Services: Technology accelerator.
+
+
+
+HEADWATERS MARKETING
+712 Garfield St.
+Fort Collins, CO 80524
+970-221-0751
+www.hw2o.com
+Company headquarters: Fort Collins
+Products/Services: Marketing firm focused on technology companies.
+Person in charge: Bill Paul VanEron, CMO/market value creation architect
+
+
+HELMS BRISCOE
+8354 S. Holland Way, Suite 204
+Littleton, CO 80128
+303 520-7717
+www.helmsbriscoe.com
+Company headquarters: Scottsdale, AZ
+Products/Services: Meeting and conference resource firm, specializing in site selection and contract negotiation. Works with corporations, associations and government agencies.
+Person in charge: leslie Padzik, Manager, Global Accounts
+
+
+INNOSPHERE
+320 E. Vine Drive
+Fort Collins, CO 80524
+970-221-1301
+www.innosphere.org
+Company headquarters: Fort Collins
+Products/Services: Innosphere is a nonprofit 501(c)3 incubator focused on supporting entrepreneurs who are building potential high-growth companies in cleantech, software, biosciences and digital health.
+
+
+
+INNOSPHERE AT CREED
+14062 Denver West Parkway, Suite 300
+Golden, CO 80401
+970-221-1301
+www.innosphere.org
+Company headquarters: Fort Collins
+Products/Services: Innosphere at CREED is located in the Colorado Center for Renewable Energy Economic Development and supports technology startup companies.
+
+
+
+INNOVATION CENTER OF THE ROCKIES
+1155 Canyon Blvd., Suite 400
+Boulder, CO 80302-5414
+303-444-2111
+www.innovationcenteroftherockies.com
+Company headquarters: Boulder
+Products/Services: Business accelerator concentrates on job creation based on technology emerging from Colorado and
+Wyoming research universities and supporting established early-stage companies.
+
+
+INTERNATIONAL ASSOCIATION OF MICROSOFT CHANNEL PARTNERSCOLORADO CHAPTER
+7350 E. Progress Place, Suite 100
+Greenwood Village, CO 80111
+303-524-2114
+www.iamcp.org
+Company headquarters: Redmond, WA
+Products/Services: IAMCP represents
+Microsoft’s best of breed partners around the globe. It provides Microsoft partners a voice into Microsoft programs and to the IT community at large.
+
+
+JEFFERSON COUNTY ECONOMIC DEVELOPMENT CORP.
+1667 Cole Blvd., Suite 400
+Golden, CO 80401
+303-202-2965
+www.jeffcoedc.org
+Company headquarters: Golden
+Products/Services: Jeffco EDC’s mission is to strengthen the economic vitality of Jefferson County through the creation, retention and expansion of primary jobs.
+
+
+
+LONGMONT ECONOMIC DEVELOPMENT PARTNERSHIP
+630 15th Ave., Suite 100A
+Longmont, CO 80501
+303-651-0128
+www.longmont.org
+Company headquarters: Longmont
+Products/Services: Lead a comprehensive, collaborative economic-development strategy to promote and strengthen the community’s economic health.
+Person in charge: Jessica Erickson , president/CEcD
+
+
+MANUFACTURER’S EDGE
+5505 Airport Blvd.
+Boulder, CO 80301
+303-592-4087
+www.manufacturersedge.com
+Company headquarters: Boulder
+Products/Services: Helps manufacturers remain competitive by providing onsite technical assistance through coaching, training and consulting, collaboration-focused industry programs and leveraging partnerships.
+
+
+
+MANUFACTURER’S EDGE
+9200 E. Mineral Ave., Suite 1150
+Centennial, CO 80112
+303-981-2144
+www.manufacturersedge.com
+Company headquarters: Centennial
+Products/Services: Helps manufacturers remain competitive by providing onsite technical assistance through coaching, training and consulting, collaboration-focused industry programs and leveraging partnerships.
+
+
+
+NATIONAL CENTER FOR WOMEN & INFORMATION TECHNOLOGY
+University of Colorado at Boulder, Campus
+Box 322
+Boulder, CO 80309-0322
+303-735-6671
+www.ncwit.org
+Company headquarters: Boulder
+Products/Services: NCWIT is a nonprofit community of more than 575 universities, companies, nonprofits and government organizations nationwide working to increase
+women’s participation in technology and computing.
+
+PROJECT MANAGEMENT INSTITUTE/PMI MILE HI CHAPTER
+2443 S. University Blvd., Suite 252
+Denver, CO 80210
+303-757-7657
+www.pmimilehi.org
+Company headquarters: Denver
+Products/Services: PMI Mile Hi is one of the largest chapters worldwide of the Project
+Management Institute (PMI), with approximately 3,500 members. PMI Mile Hi is your partner in project management excellence!
+Person in charge: Laurie Haberthier, president
+
+RECOLORADO
+6455 S. Yosemite St., Suite 500
+Greenwood Village, CO 80111
+303-850-9576
+www.recolorado.com
+Company headquarters: Greenwood Village
+Products/Services: Home search website for Colorado home buyers and sellers, and the states largest Multiple Listing Service, providing advanced technology tools for real estate professionals to use with their clients.
+Person in charge: Kirby Slunaker, President and CEO
+
+
+ROCKIES VENTURE CLUB
+1415 Park Ave. W.
+Denver, CO 80205
+720-353-9350
+www.rockiesventureclub.org
+Company headquarters: Denver
+Products/Services: Angel investing groups, conferences, events, angel and entrepreneur education, venture capital.
+Person in charge: Peter Adams, executive director
+
+
+ROCKY MOUNTAIN CHAPTER OF HDI
+P.O. Box 360065
+Littleton, CO 80163
+347-762-5434
+www.rockymountainhdi.com
+Company headquarters: Littleton
+Products/Services: RMHDI facilitates sharing industry best practices information, provides peer networking opportunities, promotes personal development, and recognizes excellence in the support industry.
+Person in charge: Jennifer Woolley, chapter president
+Phillip Rubino, chapter vice president, finance and marketing
+
+ROCKY MOUNTAIN INFORMATION MANAGEMENT ASSOCIATION
+1790 E. Easter Ave.
+Centennial, CO 80122
+720-934-7667
+www.rmima.org
+Company headquarters: Centennial
+Products/Services: The Rocky Mountain
+Information Management Association holds monthly briefings and lunch that focus on vital topics for emerging information technology leaders.
+
+
+ROCKY MOUNTAIN INNOVATION PARTNERS
+559 E. Pikes Peak Ave., Suite 101
+Colorado Springs, CO 80903
+719-685-7877
+www.rmipartners.org
+Company headquarters: Colorado Springs
+Products/Services: Combines the expertise of successful entrepreneurs, investors, and community leaders to help entrepreneurs successfully launch their business ventures.
+Person in charge: Ric Denton, president/CEO
+
+
+ROCKY MOUNTAIN VENTURE CAPITAL ASSOCIATION
+798 Pope Drive
+Erie, CO 80515
+303-482-0017
+www.rockymountainvca.com
+Company headquarters: Erie
+Products/Services: Regional venture-capital trade association that supports entrepreneurs in the technology sector in the region through networking, events and educational programs.
+
+
+
+SIGNATURE SELECT LLC
+1705 17th St., Suite 100
+Denver, CO 80202
+303-615-7645
+www.imacorp.com
+Company headquarters: Denver
+Products/Services: Specializes in providing business insurance solutions for small- to midsized companies and personal insurance to their owners and employees. Our focus is to protect assets and make a difference.
+Person in charge: Robert Cohen, CEO
+
+
+SILICON FLATIRONS CENTER FOR LAW, TECHNOLOGY AND ENTREPRENEURSHIP
+2450 Kittredge Loop Road
+Boulder, CO 80309
+303-492-5442
+www.silicon-flatirons.org
+Company headquarters: Boulder
+Products/Services: Silicon Flatirons’ core mission is to elevate the debate surrounding technology policy issues; support and enable entrepreneurship in the technology community; to inspire, prepare and place students.
+Person in charge: Phil Weiser, executive director
+
+
+STARTUP COLORADO
+Boulder, CO
+303-898-3437
+www.startupcolorado.com
+Company headquarters: Boulder
+Products/Services: Provides connections among entrepreneurs and mentors, improves access to entrepreneurial education and builds a more vibrant entrepreneurial community.
+
+
+
+
+STARTUP COLORADO SPRINGS
+Colorado Springs, CO
+www.startupcoloradosprings.com
+Company headquarters: Boulder
+Products/Services: A regional affiliate of
+Startup Colorado created to spur new company creation and entrepreneurial network density in Colorado Springs.
+
+
+
+
+STARTUP FORT COLLINS
+320 E. Vine Drive
+Fort Collins, CO 80524
+Company headquarters: Fort Collins
+Products/Services: Started as a way to multiply connections among entrepreneurs and start-up supporters in Fort Collins.
+
+
+
+
+
+STARTUP LONGMONT
+12001 Twilight St.
+Longmont, CO 80503
+303-823-6348
+Company headquarters: Longmont
+Products/Services: A not-for-profit, community service initiative to promote startups, incubators, makerspaces and entrepreneurial activity in Longmont.
+Person in charge: Michael Schnatzmeyer, co-founder
+
+
+
+STARTUPDENVER LLC
+953 S. Washington St.
+Denver, CO 80209
+720-515-6407
+www.startupdenver.com
+Company headquarters: Denver
+Products/Services: Helps startups by providing a community platform with resources and a network to help them take their idea to market.
+
+
+
+UK TRADE & INVESTMENT
+625 N. Michigan Ave., Suite 2200
+Chicago, IL 60611
+312-970-3844
+www.ukti.gov.uk
+Company headquarters: United Kingdom
+Products/Services: The British government economic-development agency works with
+Colorado technology companies looking to expand their business into the United
+Kingdom.
+
+UNIVERSITY OF COLORADO DENVER BUSINESS SCHOOL
+1475 Lawrence St.
+Denver, CO 80202
+www.business.ucdenver.edu
+Company headquarters: DENVER
+Products/Services: BUSINESS SCHOOL.
+
+
+
+
+UNIVERSITY OF COLORADO TECHNOLOGY TRANSFER OFFICE
+4845 Pearl East Circle, Suite 200
+Boulder, CO 80309
+303-860-6201
+www.cu.edu/techtransfer
+Company headquarters: Boulder
+Products/Services: Technology commercialization for University of Colorado technologies at all campuses.
+Person in charge: Kate Tallman, interim associate vice president for technology transfer
+(CU system)
+
+WORLD TRADE CENTER DENVER
+2650 E. 40th Ave.
+Denver, CO 80205
+303-592-5760
+www.wtcdenver.org
+Company headquarters: New York
+Products/Services: Facilitate international business to and from the Rocky Mountain Region, connecting our member companies to our global network of 330 World Trade Centers in 100 countries.
+Person in charge: Karen A Gerwitz, president
+
+
+ZOOMGRANTS
+8155 E. Fairmount Drive, Suite 1221
+Denver, CO 80230
+866-323-5404
+www.zoomgrants.com
+Company headquarters: Denver
+Products/Services: Online grant and scholarship management.
+Person in charge: Geoff Hamilton, president

--- a/data/test_fixtures_data/auto_transportation_technologies.txt
+++ b/data/test_fixtures_data/auto_transportation_technologies.txt
@@ -1,0 +1,218 @@
+ACTUAL SYSTEMS OF AMERICA
+3131 S. Vaughn Way, Suite 134
+Aurora, CO 80014
+303-361-2700
+www.actual-america.com
+Company headquarters: Aurora
+Products/Services: Develops and deploys software solutions for the automotive recycling industry. It developed Pinnacle
+Classic and Pinnacle Professional Automotive
+Recycling Software.
+
+AIR METHODS CORP.
+7211 S. Peoria St.
+Englewood, CO 80112
+303-792-7400
+www.airmethods.com
+Company headquarters: Englewood
+Products/Services: Air medical transport.
+
+
+
+ALPHA MOLD WEST
+7005 W. 116th Ave.
+Broomfield, CO 80020-2998
+303-465-1701
+www.alphamoldwest.com
+Company headquarters: Broomfield
+Products/Services: Makes plastic injection molds for the aerospace, appliance, automotive, computer, communications, electrical, food packaging and medical industries.
+Person in charge: Dane Whittington, president
+
+
+CAR2GO
+1580 Lincoln St., Suite 960
+Denver, CO 80203
+720-361-2959
+www.car2go.com/en/denver
+Company headquarters: Austin
+Products/Services: Car-sharing service.
+Person in charge: Michael Pletsch, location manager
+
+
+CIRCLE INDUSTRIES AND TECHNOLOGIES
+4800 Van Gordon St.
+Wheat Ridge, CO 80033
+866-435-2100
+www.ciatonline.com
+Company headquarters: Wheat Ridge
+Products/Services: Provides shop-management software solutions for the automotive industry.
+
+
+
+E-470 PUBLIC HIGHWAY AUTHORITY
+22470 E. Sixth Parkway
+Aurora, CO 80018-2425
+303-537-3748
+www.e-470.com
+Company headquarters: Aurora
+Products/Services: Electronic tolling.
+Person in charge: John McCuskey, executive director
+
+
+FLATIRON CONSTRUCTION CORP.
+385 Interlocken Crescent, Suite 900
+Broomfield, CO 80021
+303-485-4050
+www.flatironcorp.com
+Company headquarters: Broomfield
+Products/Services: Heavy civil construction
+(including: bridges, highways, light rail, tunneling, water treatment facilities, reservoir dams and transmission lines).
+Person in charge: John DiCiurcio, CEO
+
+GATES CORP.
+1551 Wewatta St.
+Denver, CO 80202
+303-744-1911
+www.gates.com
+Company headquarters: Denver
+Products/Services: Automotive aftermarket parts and services, industrial products and services. Provides engineering support for oilfield engineering services.
+
+
+
+IMI PRECISION ENGINEERING
+5400 S. Delaware St.
+Littleton, CO 80120
+303-794-2611
+www.imi-precision.com
+Products/Services: Precision-engineering company focused on rail, life sciences, food and beverage, industrial automation, energy and commercial vehicles.
+
+
+
+
+INFIELD CAPITAL
+1002 Walnut St., Suite 202
+Boulder, CO 80302
+303-449-2921
+www.infieldcapital.com
+Company headquarters: Boulder
+Products/Services: Invests in early-stage clean technologies for the transportation industry, with an emphasis on future powertrain technologies.
+
+
+
+INTUICOM INC.
+4900 Nautilus Court N., Suite 100
+Boulder, CO 80301
+303-449-4330
+www.intuicom.com
+Company headquarters: Boulder
+Products/Services: Designs and manufactures industrial wireless data solutions that enable and enhance automation, intelligent transportation, and precision GPS applications.
+Person in charge: Tom Foley, president and CEO
+
+
+KEVRON INC.
+3199 Billington Drive
+Erie, CO 80516
+720-226-0553
+www.kevron.com
+Company headquarters: Broomfield
+Products/Services: Designs, manufactures and sells laser marking systems for marking and asset tracking. Contract laser marking services.
+Person in charge: Ron Quinlan, co-owner
+Kevin Warman, co-owner, co-owners
+
+UQM TECHNOLOGIES INC.
+4120 Specialty Place
+Longmont, CO 80050
+303-682-4900
+www.uqm.com
+Company headquarters: Longmont
+Products/Services: Developer and manufacturer of power-dense, high-efficiency electric motors, generators and power electronic controllers for the automotive, commercial truck, bus and military markets.
+Person in charge: Joseph Mitchell, CEO
+
+
+LIGHTNING HYBRIDS
+319 Cleveland Ave.
+Loveland, CO 80537
+800-223-0740
+www.lightninghybrids.com
+Company headquarters: Loveland
+Products/Services: Hydraulic hybrid regenerative braking drive systems for fleet vehicles such as buses and delivery trucks.
+Person in charge: Tim Reeser, president/co-founder
+
+
+VAIREX AIR SYSTEMS
+3048 Valmont Road
+Boulder, CO 80301
+303-994-2047
+www.vairex.com
+Company headquarters: Boulder
+Products/Services: Designer and manufacturer of high-performance air compressors for the global hydrogen fuel cell and diesel emissions control markets.
+
+
+
+SAMBASAFETY
+5619 DTC Parkway, Suite 1110
+Greenwood Village, CO 80111
+888-947-2622
+www.sambasafety.com
+Company headquarters: Albuquerque, N.M.
+Products/Services: Driver risk-management solutions in North America.
+Person in charge: Richard Crawford, CEO
+
+
+VAUTO GENIUS LABS
+1625 S. Fordham St., Unit 400
+Longmont, CO 80503
+720-515-1534
+www.vauto.com
+Company headquarters: Oakbrook
+Terrace, IL
+Products/Services: Software products to aid car dealerships.
+Person in charge: Dale Pollak, founder
+
+SCHOMP BMW
+5700 S. Broadway
+Littleton, CO 80121
+303-798-1500
+www.schomp.com
+Company headquarters: Littleton
+Products/Services: A family-owned group of auto dealerships: Honda, BMW and MINI
+Cooper.
+
+
+SOLID POWER INC.
+500 S. Arthur Ave., Unit 300
+Louisville, CO 80027
+720-300-8167
+www.solidpowerbattery.com
+Company headquarters: Louisville, CO
+Products/Services: A CU-Boulder spin-out business, Solid Power develops solid-state rechargeable batteries. Target markets include automotive, consumer electronics, aerospace and military.
+Person in charge: Douglas Campbell, president & CEO
+
+
+SPECIALTY PRODUCTS CO.
+4045 Specialty Place
+Longmont, CO 80504
+303-772-2103
+www.specprod.com
+Company headquarters: Longmont
+Products/Services: Alignment and suspension parts and custom manufacturing.
+Person in charge: Benjamin Cox, CEO/president
+Mina Cox, COO
+
+UBER TECHNOLOGIES INC.
+3001 Brighton Blvd., Suite 153
+Denver, CO 80216
+720-319-1183
+www.uber.com
+Company headquarters: Denver
+Products/Services: On-demand car service, billed directly to your credit card.
+
+
+
+VECTOR AIR LLC
+Erie Municipal Airport, 48V, 395 Airport Drive
+Erie, CO 80516
+303-664-0633
+www.vectorair.net
+Company headquarters: Erie
+Products/Services: Flight instruction, aircraft maintenance and inspection.
+Person in charge: Jason Hurd, owner

--- a/data/test_fixtures_data/bioscience.txt
+++ b/data/test_fixtures_data/bioscience.txt
@@ -1,0 +1,317 @@
+ACCERA INC.
+3005 Center Green Drive, Suite 205
+Boulder, CO 80301
+303-999-3700
+www.accerapharma.com
+Company headquarters: Boulder
+Products/Services: Research and development on Alzheimer’s disease, Parkinson’s disease and related neurodegenerative disease therapeutic drugs.
+Person in charge: Charles Stacey, CEO
+
+
+ADA TECHNOLOGIES INC.
+8100 Shaffer Parkway, Suite 130
+Littleton, CO 80127-4107
+303-792-5615
+www.adatech.com
+Company headquarters: Littleton
+Products/Services: ADA Technologies is a research, development and commercialization organization that works with scientists and business professionals to identify and develop R&D and commercialization opportunities.
+
+
+
+ADVANCED MICROLABS
+3185-A Rampart Road
+Fort Collins, CO 80521
+970-492-4383
+www.advancedmicrolabs.com
+Company headquarters: Fort Collins
+Products/Services: Makes detection technology for microchip capillary electrophoresis.
+Person in charge: Charles Henry, CEO
+
+
+ADVANCED REGENERATIVE THERAPIES
+320 E. Vine Drive, Suite 122
+Fort Collins, CO 80524
+970-222-9831
+www.art4dvm.com
+Company headquarters: Fort Collins
+Products/Services: Uses stem cells derived from the bone marrow of equine and canine to treat equine athlete joint injuries.
+Person in charge: Cristin Keohan, laboratory director
+
+
+ADVANCED THIN FILMS LLC
+5733 Central Ave.
+Boulder, CO 80301
+303-815-1545
+www.atf-ppc.com
+Company headquarters: Boulder
+Products/Services: Precision optical components and ion beam sputtered coatings for applications in scientific research, defense, aerospace, telecommunications, laser and semiconductor manufacturing.
+Person in charge: Robert Beeson, general manager
+
+
+AEGIS CREATIVE
+44 Union Blvd., Suite 250
+Lakewood, CO 80228
+303-973-5566
+www.aegiscreative.com
+Company headquarters: Lakewood
+Products/Services: Works with biopharmaceutical, device, diagnostics and technology companies to implement innovations in health care.
+Person in charge: Dawn Repola, president, CEO
+
+
+AFFYGILITY SOLUTIONS
+13498 Cascade St.
+Broomfield, CO 80020
+303-884-3028
+www.affygility.com
+Company headquarters: Broomfield
+Products/Services: Environmental health and safety services and software for biotech, pharmaceutical and other life science organizations.
+Person in charge: Dean Calhoun, CEO
+
+
+AGILENT TECHNOLOGIES INC., NUCLEIC ACID SOLUTIONS DIVISION
+5555 Airport Road
+Boulder, CO 80301
+303-222-4900
+www.agilent.com
+Company headquarters: Santa Clara, CA
+Products/Services: Flexible therapeutic oligonucleotide development services and manufacturing for the biotech and pharmaceutical industries.
+
+
+
+AKTIV-DRY LLC
+655 Northstar Court
+Boulder, CO 80304
+303-447-0788
+www.aktiv-dry.com
+Company headquarters: Boulder
+Products/Services: Licenses drying and aerosodelivery processes. Dry powder processing solutions; microparticles and nanoparticles research and development; inhalable pharmaceuticals.
+Person in charge: Robert E. Sievers, cofounder, CEO and president
+
+
+ALLOSOURCE
+6278 S. Troy Circle
+Centennial, CO 80111
+720-873-0213
+www.allosource.org
+Company headquarters: Centennial
+Products/Services: Conducts research on and develops allograft technology.
+Person in charge: Tom Cycyota, president, CEO
+
+
+AMGEN INC.
+4000 Nelson Road
+Longmont, CO 80503
+303-401-1000
+www.amgen.com
+Company headquarters: Thousand Oaks, CA
+Products/Services: Manufacturer of biologics.
+Person in charge: Robert Bradway, CEO/president
+
+
+AMIDEBIO LLC
+331 S. 104th St.
+Louisville, CO 80027
+303-604-0296
+www.amidebio.com
+Company headquarters: Boulder
+Products/Services: Focused on providing peptide and protein research reagents and clinical products for a diverse array of research and commercial targets.
+Person in charge: Misha Plam, president, CEO
+
+
+AMPIO PHARMACEUTICALS
+373 Inverness Parkway, Suite 200
+Englewood, CO 80112
+720-437-6500
+www.ampiopharma.com
+Company headquarters: Englewood
+Products/Services: Development stage biopharmaceutical company focused on the discovery and development of novel therapies aimed at treating common inflammatory conditions for which there are limited treatment options.
+
+
+
+ANIMARK INC.
+876 Ventura St.
+Aurora, CO 80011
+303-343-8342
+www.animark.us
+Company headquarters: Aurora
+Products/Services: Manufactures high-tech livestock breeding equipment.
+
+
+
+ANTRIABIO INC.
+1450 Infinite Drive
+Louisville, CO 80027
+303-222-2128
+www.antriabio.com
+Company headquarters: Louisvillle
+Products/Services: A recombinant human basal insulin formulated for once weekly injection that has the potential to significantly advance the treatment paradigm for insulin replacement therapy.
+
+
+
+APDYNE MEDICAL CO.
+1049 S. Vine St.
+Denver, CO 80209-4622
+303-698-4802
+www.apdyne.com
+Company headquarters: Denver
+Products/Services: Manufacturer of the Apdyne Phenol Applicator Kit used to anesthetize the tympanic membrane during in-office myringotomy procedures.
+
+
+
+APOPLOGIC PHARMACEUTICALS LLC
+12635 E. Montview Blvd., Suite 100
+Aurora, CO 80045
+www.apoplogic.com
+Company headquarters: Aurora
+Products/Services: A clinical-stage biopharmaceutical company that developed
+Breceptin, an oncolytic drug for the treatment of a wide range of solid tumors.
+Person in charge: Richard C Duke, president, CEO
+
+
+ATLAS BIOLOGICALS INC.
+2649 E. Mulberry St., Suite A-3
+Fort Collins, CO 80524
+866-222-8988
+www.atlasbio.com
+Company headquarters: Fort Collins
+Products/Services: Fetal bovine serum.
+
+
+
+ARCA BIOPHARMA INC.
+11080 Circle Point Road, Suite 140
+Westminster, CO 80020
+720-940-2100
+www.arcabiopharma.com
+Company headquarters: Westminster
+Products/Services: Genetically targeted therapies for heart failure and other cardiovascular diseases.
+Person in charge: Michael R. Bristow, CEO
+
+
+ARCSCAN INC.
+433 Park Point Drive, Suite 220
+Golden, CO 80401
+773-387-5548
+www.arcscan.com
+Company headquarters: Morrison
+Products/Services: High-resolution ultrasound scanners for ophthalmology.
+
+
+
+ARRAY BIOPHARMA INC.
+3200 Walnut St.
+Boulder, CO 80301
+303-381-6600
+www.arraybiopharma.com
+Company headquarters: Boulder
+Products/Services: Discovers, develops and commercializes targeted small molecule drugs to treat patients afflicted with cancer.
+Person in charge: Ron Squarer, CEO
+
+
+ASIUS TECHNOLOGIES LLC
+1257 Whitehall Drive
+Longmont, CO 80504
+720-204-2676
+www.asiustechnologies.com
+Company headquarters: Longmont
+Products/Services: Inflatable in-ear audio technology.
+
+
+
+ASPEN ELECTRONICS MANUFACTURING INC.
+8975 Marshall Court, Suite 100
+Westminster, CO 80031
+303-412-1216
+aemtronics.com
+Company headquarters: Westminster
+Products/Services: Engineering contract manufacturing company, providing printed circuit board assembly services for computer, commercial, aerospace and medical device industries.
+
+
+
+ASPIRE BIOTECH INC.
+4755 Forge Road, Suite 120
+Colorado Springs, CO 80907
+719-522-9800
+www.aspirebiotech.com
+Company headquarters: Colorado Springs
+Products/Services: An R&D company focused on improving medical devices through the development of superior biomaterials.
+
+
+
+ASTRAZENECA
+5550 Airport Blvd
+Boulder, CO 80301
+303-402-7400
+Company headquarters: London
+Products/Services: Manufactures biologics.
+
+
+
+
+AUROGEN INC.
+P.O. Box B
+Fort Collins, CO 80522
+970-491-7339
+Company headquarters: Fort Collins
+Products/Services: Developer of patented pharmaceutical treatments for diabetic neuropathy and Alzheimer’s disease.
+
+
+
+
+AVIDITY LLC
+12635 E. Montview Blvd., Suite 140
+Aurora, CO 80045
+720-859-6111
+www.avidity.com
+Company headquarters: Aurora
+Products/Services: Develops and sells molecular affinity tools for connecting molecules.
+
+
+
+AWEIDA VENTURE PARTNERS
+500 Discovery Parkway, Suite 300
+Superior, CO 80027
+303-664-9520
+www.aweida.com
+Company headquarters: Superior
+Products/Services: Data storage, software and the life sciences.
+
+
+
+BAROFOLD INC.
+12635 E. Montview Blvd.
+Aurora, CO 80045
+www.barofold.com
+Company headquarters: Aurora
+Products/Services: BaroFold applies its
+Pressure Enabled Protein Manufacturing technology to improve the tolerability, efficacy and safety of a wide variety of protein therapeutics for biopharmaceutical companies.
+Person in charge: Matt Brewer, CEO
+Matt Seefeldt, CEO, CEOs
+
+BAXTER HEALTHCARE CORP.
+14445 Grasslands Drive
+Englewood, CO 80112
+303-690-4204
+www.baxter.com
+Company headquarters: Deerfield, IL
+Products/Services: Develops, manufactures and markets products that save and sustain the lives of people with hemophilia, immune disorders and infectious diseases.
+
+
+
+BEACON BIOTECHNOLOGY
+12635 E. Montview Blvd.
+Aurora, CO 80045
+720-859-6116
+www.beaconbiotechnology.com
+Company headquarters: Aurora
+Products/Services: Single-use, disposable device that can perform hundreds of diagnostic tests on a single drop of blood.
+Person in charge: Millard Cull, CEO
+
+
+BIOBUBBLE INC.
+1411 E. Magnolia St.
+Fort Collins, CO 80524
+970-224-4262
+www.biobubble.com
+Company headquarters: Fort Collins
+Products/Services: Softwall clean and containment enclosures, HEPA air systems

--- a/db/migrate/20161103205226_add_phone_to_companies.rb
+++ b/db/migrate/20161103205226_add_phone_to_companies.rb
@@ -1,0 +1,5 @@
+class AddPhoneToCompanies < ActiveRecord::Migration[5.0]
+  def change
+    add_column :companies, :phone, :citext
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161103175718) do
+ActiveRecord::Schema.define(version: 20161103205226) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -33,6 +33,7 @@ ActiveRecord::Schema.define(version: 20161103175718) do
     t.citext   "person_in_charge"
     t.datetime "created_at",        null: false
     t.datetime "updated_at",        null: false
+    t.citext   "phone"
     t.index ["category_id"], name: "index_companies_on_category_id", using: :btree
   end
 

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -1,6 +1,6 @@
 namespace :db do
   desc "TODO"
-  task :seed_test_fixture, [:path] :environment do
+  task :seed_test_fixture, [:path] => :environment do
 
   end
 end

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -1,5 +1,6 @@
 namespace :db do
-  desc "TODO"
+  desc "Import companies into the database from a parsed text file"
+  # The text file must be formatted with exactly one company per exactly ten lines with exactly one attribute per line in the order of: name, street_address, city_state_zip, phone, website, headquarters, products_services, person_in_charge
   task :seed_test_fixture, [:path] => :environment do |t, args|
     lines = File.new(args[:path]).readlines.map { |line| line.chomp }
 

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -3,8 +3,8 @@ namespace :db do
   task :seed_test_fixture, [:path] => :environment do |t, args|
     lines = File.new(args[:path]).readlines.map { |line| line.chomp }
 
-    category = File.basename(args[:path], ".txt")
-    Category.create!(name: category)
+    category_name = File.basename(args[:path], ".txt")
+    category = Category.create!(name: category_name)
 
     companies = []
 
@@ -13,16 +13,25 @@ namespace :db do
     end
 
     companies.each do |company|
-      Company.create!(
-        name: company[0]
-        street_address: company[1]
-        city_state_zip: company[2]
-        phone: company[3]
-        website: company[4]
-        headquarters: company[5]
-        products_services: company[6]
-        person_in_charge: company[7]
-      )
+      name              = company[0]
+      street_address    = company[1]
+      city_state_zip    = company[2]
+      phone             = company[3]
+      website           = company[4]
+      headquarters      = company[5].sub("Company headquarters: ", "")
+      products_services = company[6].sub("Products/Services: ", "")
+      person_in_charge  = company[7].sub("Person in charge: ", "")
+
+      category.companies << Company.new({
+        name:              name,
+        street_address:    street_address,
+        city_state_zip:    city_state_zip,
+        phone:             phone,
+        website:           website,
+        headquarters:      headquarters,
+        products_services: products_services,
+        person_in_charge:  person_in_charge
+      })
     end
   end
 end

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -1,6 +1,28 @@
 namespace :db do
   desc "TODO"
-  task :seed_test_fixture, [:path] => :environment do
+  task :seed_test_fixture, [:path] => :environment do |t, args|
+    lines = File.new(args[:path]).readlines.map { |line| line.chomp }
 
+    category = File.basename(args[:path], ".txt")
+    Category.create!(name: category)
+
+    companies = []
+
+    lines.each_slice(10) do |ten_lines|
+      companies << ten_lines
+    end
+
+    companies.each do |company|
+      Company.create!(
+        name: company[0]
+        street_address: company[1]
+        city_state_zip: company[2]
+        phone: company[3]
+        website: company[4]
+        headquarters: company[5]
+        products_services: company[6]
+        person_in_charge: company[7]
+      )
+    end
   end
 end

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -1,6 +1,6 @@
 namespace :db do
   desc "TODO"
-  task seed_test_data: :environment do
+  task :seed_test_fixture, [:path] :environment do
 
   end
 end

--- a/spec/lib/tasks/db_rake_spec.rb
+++ b/spec/lib/tasks/db_rake_spec.rb
@@ -1,10 +1,13 @@
 require 'rails_helper'
 require 'rake'
 
-describe "db:seed_test_data" do
-  fixture_file = "agricultural_technology.txt"
-  fixture_path = File.join(Rails.root, "data", "test_fixtures_data", fixture_file)
-  Rake::Task[db:seed_test_fixture].invoke(fixture_path)
+RSpec.describe "db" do
+  it "seeds the test database from the fixture data" do
+    fixture_file = "agricultural_technology.txt"
+    fixture_path = File.join(Rails.root, "data", "test_fixtures_data", fixture_file)
+    require "pry"; binding.pry
+    Rake::Task[db:seed_test_fixture].invoke(fixture_path)
 
-  expect(Company.count).to eq(10)
+    expect(Company.count).to eq(10)
+  end
 end

--- a/spec/lib/tasks/db_rake_spec.rb
+++ b/spec/lib/tasks/db_rake_spec.rb
@@ -1,12 +1,16 @@
+# Reference: https://robots.thoughtbot.com/test-rake-tasks-like-a-boss
+
 require 'rails_helper'
 require 'rake'
 
-RSpec.describe "db" do
+RSpec.describe "db:seed_test_fixture" do
+  include_context "rake"
+
   it "seeds the test database from the fixture data" do
     fixture_file = "agricultural_technology.txt"
     fixture_path = File.join(Rails.root, "data", "test_fixtures_data", fixture_file)
-    require "pry"; binding.pry
-    Rake::Task[db:seed_test_fixture].invoke(fixture_path)
+
+    subject.invoke(fixture_path)
 
     expect(Company.count).to eq(10)
   end

--- a/spec/lib/tasks/db_rake_spec.rb
+++ b/spec/lib/tasks/db_rake_spec.rb
@@ -14,6 +14,26 @@ RSpec.describe "db:seed_test_fixture" do
 
     expect(Category.count).to eq(1)
     expect(Category.last.name).to eq(File.basename(fixture_file, ".txt"))
-    expect(Company.count).to eq(10)
+    expect(Company.count).to eq(22)
+
+    expect(Company.first.category).to eq(Category.last)
+    expect(Company.first.name).to eq("ADVANCED REGENERATIVE THERAPIES")
+    expect(Company.first.street_address).to eq("320 E. Vine Drive, Suite 122")
+    expect(Company.first.city_state_zip).to eq("Fort Collins, CO 80524")
+    expect(Company.first.phone).to eq("970-222-9831")
+    expect(Company.first.website).to eq("www.art4dvm.com")
+    expect(Company.first.headquarters).to eq("Fort Collins")
+    expect(Company.first.products_services).to eq("Uses stem cells derived from the bone marrow of equine and canine to treat equine athlete joint injuries.")
+    expect(Company.first.person_in_charge).to eq("Cristin Keohan, laboratory director")
+
+    expect(Company.last.category).to eq(Category.last)
+    expect(Company.last.name).to eq("ZEOPONIX INC.")
+    expect(Company.last.street_address).to eq("P.O. Box 19105")
+    expect(Company.last.city_state_zip).to eq("Boulder, CO 80308")
+    expect(Company.last.phone).to eq("303-673-0098")
+    expect(Company.last.website).to eq("www.zeoponix.com")
+    expect(Company.last.headquarters).to eq("Boulder")
+    expect(Company.last.products_services).to eq("Zeoponic soil amendment/fertilizer, NASA spin off, high efficiency ion exchange nutrient delivery; horticulture, sports/golf, forestry, agriculture, landscaping, greenroofs, aquaponics, reclamation.")
+    expect(Company.last.person_in_charge).to eq("Richard Andrews, CEO")
   end
 end

--- a/spec/lib/tasks/db_rake_spec.rb
+++ b/spec/lib/tasks/db_rake_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+describe "db:seed_test_data" do
+  
+end

--- a/spec/lib/tasks/db_rake_spec.rb
+++ b/spec/lib/tasks/db_rake_spec.rb
@@ -12,6 +12,8 @@ RSpec.describe "db:seed_test_fixture" do
 
     subject.invoke(fixture_path)
 
+    expect(Category.count).to eq(1)
+    expect(Category.last.name).to eq(File.basename(fixture_file, ".txt"))
     expect(Company.count).to eq(10)
   end
 end

--- a/spec/lib/tasks/db_rake_spec.rb
+++ b/spec/lib/tasks/db_rake_spec.rb
@@ -1,5 +1,10 @@
 require 'rails_helper'
+require 'rake'
 
 describe "db:seed_test_data" do
-  
+  fixture_file = "agricultural_technology.txt"
+  fixture_path = File.join(Rails.root, "data", "test_fixtures_data", fixture_file)
+  Rake::Task[db:seed_test_fixture].invoke(fixture_path)
+
+  expect(Company.count).to eq(10)
 end

--- a/spec/support/shared_contexts/rake.rb
+++ b/spec/support/shared_contexts/rake.rb
@@ -1,0 +1,21 @@
+# Reference: https://robots.thoughtbot.com/test-rake-tasks-like-a-boss
+
+require "rake"
+
+shared_context "rake" do
+  let(:rake)      { Rake::Application.new }
+  let(:task_name) { self.class.top_level_description }
+  let(:task_path) { "lib/tasks/#{task_name.split(":").first}" }
+  subject         { rake[task_name] }
+
+  def loaded_files_excluding_current_rake_file
+    $".reject {|file| file == Rails.root.join("#{task_path}.rake").to_s }
+  end
+
+  before do
+    Rake.application = rake
+    Rake.application.rake_require(task_path, [Rails.root.to_s], loaded_files_excluding_current_rake_file)
+
+    Rake::Task.define_task(:environment)
+  end
+end


### PR DESCRIPTION
The fixtures are company data that have been parsed into text files in a very specific way. The text file must be formatted with exactly one company per exactly ten lines with exactly one attribute per line in the order of: name, street_address, city_state_zip, phone, website, headquarters, products_services, person_in_charge. 

At this point this is primarily intended for testing purposes. We will want an automated data parser in the future and unless it formats data exactly like this then it will need a new rake task to import that dataset.